### PR TITLE
Add timeout to read in vcs-status.sh (Issue #5)

### DIFF
--- a/scripts/vcs-status.sh
+++ b/scripts/vcs-status.sh
@@ -10,7 +10,7 @@ cd "$PWD"
 if ! command -v nvim &>/dev/null; then
   printf '\n  nvim is not installed.\n\n'
   printf '  Press any key to close.'
-  read -n1
+  read -t 5 -n1
   exit 1
 fi
 
@@ -21,5 +21,5 @@ elif hg root &>/dev/null; then
 else
   printf '\n  Not a git or hg repository.\n\n'
   printf '  Press any key to close.'
-  read -n1
+  read -t 5 -n1
 fi


### PR DESCRIPTION
## Summary
- Add 5-second timeout (`-t 5`) to `read -n1` calls in `vcs-status.sh`

Prevents indefinite hang when stdin is closed in non-interactive contexts.

Closes #5