### PR TITLE
Centralize supported agent list in _agents.sh

### DIFF
--- a/scripts/_agents.sh
+++ b/scripts/_agents.sh
@@ -2,6 +2,9 @@
 # Shared agent configuration — launch commands, pause/resume.
 # Source this file; do not execute directly.
 
+# Single source of truth for supported agent names.
+KNOWN_AGENTS="claude gemini aider codex goose interpreter"
+
 # Build the command array for launching an agent with a prompt.
 # Sets the caller's cmd_args array.
 agent_build_cmd() {

--- a/scripts/deck.sh
+++ b/scripts/deck.sh
@@ -230,7 +230,7 @@ detect_agent() {
   local child_cmds
   child_cmds=$(ps -o comm= -p $children 2>/dev/null) || return 1
   local name
-  for name in claude gemini aider codex goose interpreter; do
+  for name in $KNOWN_AGENTS; do
     if grep -qw "$name" <<< "$child_cmds"; then
       printf '%s' "$name"
       return

--- a/scripts/new-agent.sh
+++ b/scripts/new-agent.sh
@@ -7,14 +7,11 @@ set -uo pipefail
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/_agents.sh"
 
-# Detect available coding agents
+# Detect available coding agents from the shared list
 agents=""
-command -v claude &>/dev/null && agents+="claude"$'\n'
-command -v gemini &>/dev/null && agents+="gemini"$'\n'
-command -v aider &>/dev/null && agents+="aider"$'\n'
-command -v codex &>/dev/null && agents+="codex"$'\n'
-command -v goose &>/dev/null && agents+="goose"$'\n'
-command -v interpreter &>/dev/null && agents+="interpreter"$'\n'
+for name in $KNOWN_AGENTS; do
+  command -v "$name" &>/dev/null && agents+="${name}"$'\n'
+done
 agents="${agents%$'\n'}"
 
 if [[ -z "$agents" ]]; then


### PR DESCRIPTION
## Summary
- Add `KNOWN_AGENTS` variable in `_agents.sh` as the single source of truth
- `new-agent.sh` agent detection loop now iterates over `$KNOWN_AGENTS`
- `deck.sh` `detect_agent()` fallback scan now uses `$KNOWN_AGENTS`
- Adding a new agent is now a one-line change instead of editing 3 files

## Test plan
- [ ] Launch a new agent (`prefix+a`) and verify all installed agents are detected
- [ ] Open the deck and verify pause/resume still detects the correct agent

Fixes #8