### PR TITLE
Add PEP 723 inline script metadata for uv run

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # /// script
+# requires-python = ">=3.10"
 # dependencies = ["fastmcp>=2.0"]
 # ///
 """tmux-pilot MCP server — agent lifecycle tools for MCP-capable clients."""


### PR DESCRIPTION
## Summary
- Adds [PEP 723](https://peps.python.org/pep-0723/) inline script metadata to `mcp/server.py` so `uv run` automatically installs `fastmcp>=2.0` without needing a separate virtualenv or `pip install`

## Test plan
- [ ] Run `env -u CLAUDECODE uv run ~/.tmux/plugins/tmux-pilot/mcp/server.py --help` and confirm the server starts