### PR TITLE
Add capture_pane and send_keys MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ Or add to `~/.gemini/settings.json`:
 | `pause_agent` | Gracefully pause a running agent (keeps pane alive for resume) |
 | `resume_agent` | Resume a previously paused agent |
 | `kill_agent` | Kill an agent session and clean up its worktree |
+| `capture_pane` | Capture terminal text from a pane (target, optional line count) |
+| `send_keys` | Send text or control keys to a pane (uses paste-buffer for text to bypass popups) |
 
 ## License
 


### PR DESCRIPTION
## Summary

- **`capture_pane`** — read terminal output from any pane (configurable line count, default 20)
- **`send_keys`** — send text or control keys to a pane using a hybrid approach: `paste-buffer` for text payloads (bypasses tmux popup/overlay interception), `send-keys` for control characters

These are the two most frequently needed operations when orchestrating agents programmatically — reading output to monitor progress and sending input to approve prompts or correct course.

## Test plan

- [ ] `capture_pane` returns terminal text for a valid target
- [ ] `capture_pane` respects the `lines` parameter
- [ ] `send_keys` delivers text via paste-buffer (verify text arrives in pane)
- [ ] `send_keys` delivers special keys (Enter, C-c, BTab) via send-keys
- [ ] `send_keys` text delivery works even when a tmux popup is open
- [ ] Both tools return errors for invalid targets