### PR TITLE
Fix Gemini spawning to use login shell for nvm PATH

### DIFF
--- a/scripts/_agents.sh
+++ b/scripts/_agents.sh
@@ -10,6 +10,7 @@ KNOWN_AGENTS="claude gemini aider codex goose interpreter"
 agent_build_cmd() {
   local agent="$1" prompt="$2"
   case "$agent" in
+    gemini)      cmd_args=(bash -lc 'exec gemini "$0"' "$prompt") ;;
     aider)       cmd_args=(aider --message "$prompt") ;;
     goose)       cmd_args=(goose run "$prompt") ;;
     interpreter) cmd_args=(interpreter --message "$prompt") ;;
@@ -34,6 +35,7 @@ agent_resume() {
   local target="$1" agent="$2"
   case "$agent" in
     claude)      tmux send-keys -t "$target" 'claude --continue' Enter ;;
+    gemini)      tmux send-keys -t "$target" "bash -lc gemini" Enter ;;
     goose)       tmux send-keys -t "$target" 'goose session resume' Enter ;;
     *)           tmux send-keys -t "$target" "$agent" Enter ;;
   esac


### PR DESCRIPTION
## Summary

- Add explicit `gemini)` case in `agent_build_cmd()` that wraps the command in `bash -lc` so nvm initializes and the `gemini` binary is found on PATH
- Add explicit `gemini)` case in `agent_resume()` for the same reason

## Context

Gemini CLI is installed via nvm (`~/.nvm/versions/node/.../bin/gemini`). Since nvm only initializes PATH in login shells, tmux-pilot's non-login shell sessions couldn't find the binary. This caused `spawn_agent(agent="gemini")` to fail silently.

## Test plan

- [ ] `bash -n scripts/_agents.sh` passes
- [ ] `spawn_agent(agent="gemini", ...)` successfully launches Gemini in a tmux session