### PR TITLE
Add run_command_silent MCP tool and deck status UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Each agent gets its own tmux session. The session name is derived from the promp
 
 An fzf-based popup listing all panes across all sessions, sorted by most recent activity, with a live preview of each pane's output. Column widths adapt dynamically to the terminal size.
 
-Columns: **Session:Index** | **Window** | **Age** | **CPU** | **RAM**
+Columns: **Session:Index** | **Window** | **Status** | **Age** | **CPU** | **RAM**
 
 CPU and RAM are computed per pane by summing the entire process tree (shell + agent + child processes), so you can spot runaway agents at a glance.
 
@@ -65,6 +65,8 @@ Example:
 | `Alt+R` | Resume agent (sends `claude --continue`, only works after pause) |
 | `Alt+N` | Launch new agent |
 | `Alt+E` | Edit session description |
+| `Alt+Y` | Approve (send Enter to selected pane) |
+| `Alt+L` | View watchdog log |
 | `Esc` | Close deck |
 
 The preview panel (right side, 60%) shows metadata for the selected pane:
@@ -172,6 +174,25 @@ tmux set-option -p @pilot-desc "migrate auth to Compose"
 ```
 
 Only panes with a description show the DESC line — others are unaffected.
+
+### Pane Variables
+
+tmux-pilot uses pane-level variables for metadata.
+External tools can set additional variables that
+tmux-pilot will display in the deck.
+
+| Variable | Set by | Read by | Values |
+|----------|--------|---------|--------|
+| `@pilot-agent` | spawn.sh | deck, monitor | claude, gemini, ... |
+| `@pilot-desc` | spawn.sh, agent | deck | Task description |
+| `@pilot-workdir` | agent hook | deck, kill.sh | Current dir |
+| `@pilot-status` | external tool | deck | working, stuck, done |
+| `@pilot-needs-help` | external tool | deck | "" or description |
+
+tmux-pilot reads and displays `@pilot-status` and
+`@pilot-needs-help` but does not set them. External
+tools (watchdog daemons, orchestrators) write these
+variables to communicate agent state.
 
 ## Working directory tracking
 
@@ -318,6 +339,7 @@ Or add to `~/.gemini/settings.json`:
 | `capture_pane` | Capture terminal text from a pane (target, optional line count) |
 | `send_keys` | Send text or control keys to a pane (uses paste-buffer for text to bypass popups) |
 | `monitor_agents` | Monitor all agent panes for permission prompts (risk-classified) and lifecycle events |
+| `run_command_silent` | Run a command silently, return exit code and tail of output (full output saved to log file) |
 
 ## License
 

--- a/scripts/_preview.sh
+++ b/scripts/_preview.sh
@@ -44,6 +44,8 @@ pane_start=$(tmux display-message -t "$target" -p '#{pane_start_command}' 2>/dev
 desc=$(tmux display-message -t "$target" -p '#{@pilot-desc}' 2>/dev/null) || desc=""
 pilot_host=$(tmux display-message -t "$target" -p '#{@pilot-host}' 2>/dev/null) || pilot_host=""
 pilot_mode=$(tmux display-message -t "$target" -p '#{@pilot-mode}' 2>/dev/null) || pilot_mode=""
+pilot_status=$(tmux display-message -t "$target" -p '#{@pilot-status}' 2>/dev/null) || pilot_status=""
+pilot_needs_help=$(tmux display-message -t "$target" -p '#{@pilot-needs-help}' 2>/dev/null) || pilot_needs_help=""
 
 now=$(date +%s)
 
@@ -130,6 +132,10 @@ if [[ -n "$pilot_host" ]]; then
 fi
 if [[ -n "$desc" ]]; then
   printf '\033[1mDESC:\033[0m    %s%s\n' "$desc" "$host_suffix"
+elif [[ -n "$pilot_needs_help" ]]; then
+  printf '\033[1;33mSTATUS:\033[0m  ⚠ NEEDS HELP: %s\n' "$pilot_needs_help"
+elif [[ -n "$pilot_status" ]]; then
+  printf '\033[1mSTATUS:\033[0m  %s%s\n' "$pilot_status" "$host_suffix"
 elif [[ -n "$pilot_host" ]]; then
   printf '\033[1mHOST:\033[0m    %s (%s)\n' "$pilot_host" "$pilot_mode"
 else


### PR DESCRIPTION
## Summary
- Add `run_command_silent` MCP tool that runs commands with stdout/stderr redirected to a temp log file, returning only exit code and tail of output to keep LLM context clean
- Add STATUS column to the deck UI reading from `@pilot-status` and `@pilot-needs-help` pane variables
- Add `Alt-Y` (approve/send Enter) and `Alt-L` (view watchdog log) keybindings to the deck
- Add status display to the preview header (shown in the DESC line slot when no description is set)
- Document standard pane variables in README

## Test plan
- [ ] Verify `run_command_silent` with a successful command (exit code 0, empty tail)
- [ ] Verify `run_command_silent` with a failing command (non-zero exit, last 30 lines in tail)
- [ ] Verify `run_command_silent` timeout behavior
- [ ] Set `@pilot-status` on a pane and confirm it appears in the deck STATUS column
- [ ] Set `@pilot-needs-help` and confirm the ⚠ prefix appears
- [ ] Test `Alt-Y` sends Enter to the selected pane
- [ ] Test `Alt-L` opens the watchdog log (or shows "not found" message)
- [ ] Confirm preview header shows STATUS when desc is empty but status is set