### PR TITLE
Add Vibe agent support and tier/trust pane variables

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -65,11 +65,13 @@ def spawn_agent(
     host: str | None = None,
     mode: str | None = None,
     owner: str | None = None,
+    tier: str | None = None,
+    trust: str | None = None,
 ) -> str:
     """Create a new AI agent in its own tmux session.
 
     Args:
-        agent: Agent name (claude, gemini, aider, codex, goose, interpreter).
+        agent: Agent name (claude, gemini, aider, codex, goose, interpreter, vibe).
         prompt: The task prompt to send to the agent.
         directory: Working directory for the agent session.
         session_name: Optional session name (auto-generated from prompt if omitted).
@@ -80,6 +82,8 @@ def spawn_agent(
         owner: Optional owner pane ID (e.g. "%5"). Overrides $TMUX_PANE
                auto-detection. Use when the MCP server runs outside tmux
                (e.g. remote MCP) and the caller knows its own pane ID.
+        tier: Optional tier label (string). Sets @pilot-tier pane variable.
+        trust: Optional trust level (string). Sets @pilot-trust pane variable.
     """
     # Explicit owner overrides auto-detection.
     # Fall back to $TMUX_PANE (works when the MCP
@@ -102,6 +106,10 @@ def spawn_agent(
         cmd += ["--mode", mode]
     if effective_owner:
         cmd += ["--owner", effective_owner]
+    if tier:
+        cmd += ["--tier", tier]
+    if trust:
+        cmd += ["--trust", trust]
 
     result = _run(cmd)
     if result.returncode != 0:

--- a/scripts/_agents.sh
+++ b/scripts/_agents.sh
@@ -3,7 +3,7 @@
 # Source this file; do not execute directly.
 
 # Single source of truth for supported agent names.
-KNOWN_AGENTS="claude gemini aider codex goose interpreter"
+KNOWN_AGENTS="claude gemini aider codex goose interpreter vibe"
 
 # Build the command array for launching an agent with a prompt.
 # Sets the caller's cmd_args array.
@@ -11,6 +11,7 @@ agent_build_cmd() {
   local agent="$1" prompt="$2"
   case "$agent" in
     gemini)      cmd_args=(bash -lc 'exec gemini -y "$0"' "$prompt") ;;
+    vibe)        cmd_args=(vibe --prompt "$prompt") ;;
     aider)       cmd_args=(aider --message "$prompt") ;;
     goose)       cmd_args=(goose run "$prompt") ;;
     interpreter) cmd_args=(interpreter --message "$prompt") ;;
@@ -33,6 +34,7 @@ agent_pause() {
   case "$agent" in
     claude)      _send_text "$target" '/exit' ;;
     gemini)      _send_text "$target" '/quit' ;;
+    vibe)        _send_text "$target" '/exit' ;;
     aider)       _send_text "$target" '/exit' ;;
     goose)       tmux send-keys -t "$target" C-d ;;
     *)           tmux send-keys -t "$target" C-c ;;
@@ -47,6 +49,7 @@ agent_resume() {
   case "$agent" in
     claude)      _send_text "$target" 'claude --continue' ;;
     gemini)      _send_text "$target" "bash -lc 'gemini -y'" ;;
+    vibe)        _send_text "$target" 'vibe' ;;
     goose)       _send_text "$target" 'goose session resume' ;;
     *)           _send_text "$target" "$agent" ;;
   esac


### PR DESCRIPTION
## Summary
- Add `vibe` to `KNOWN_AGENTS` with spawn (`vibe --prompt`), pause (`/exit`), and resume (`vibe`) commands
- Add `tier` and `trust` parameters to `spawn_agent()` MCP tool, setting `@pilot-tier` and `@pilot-trust` pane variables
- Pass `--tier` and `--trust` through `spawn.sh` for all three spawn modes (local, local-ssh, remote-tmux)

Related: AlexBurdu/alexlibraria#371 (Vibe CLI integration)