### PR TITLE
Disable autocomplete for spawned Claude agents

### DIFF
--- a/scripts/_agents.sh
+++ b/scripts/_agents.sh
@@ -15,6 +15,7 @@ agent_build_cmd() {
     aider)       cmd_args=(aider --message "$prompt") ;;
     goose)       cmd_args=(goose run "$prompt") ;;
     interpreter) cmd_args=(interpreter --message "$prompt") ;;
+    claude)      cmd_args=(env CLAUDE_CODE_DISABLE_AUTOCOMPLETE=true CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude "$prompt") ;;
     *)           cmd_args=("$agent" "$prompt") ;;
   esac
 }

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -132,6 +132,9 @@ fi
 # use: tmux set-environment -g VAR value
 tmux_cmd=$(printf '%q ' "${cmd_args[@]}")
 path_prefix='PATH="$HOME/.local/bin:$HOME/bin:$HOME/go/bin:$PATH"'
+if [[ "$agent" == "claude" ]]; then
+  path_prefix="export CLAUDE_CODE_DISABLE_AUTOCOMPLETE=true; export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false; $path_prefix"
+fi
 desc="${prompt:0:80}"
 
 if [[ "$mode" == "remote-tmux" ]]; then


### PR DESCRIPTION
Fixes autocomplete interception of programmatic Enter keypresses. Sets CLAUDE_CODE_DISABLE_AUTOCOMPLETE=true and CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false when spawning Claude agents.