### PR TITLE
Fix multiline @pilot-desc breaking pane parser

### DIFF
--- a/mcp/agents.py
+++ b/mcp/agents.py
@@ -145,9 +145,27 @@ def parse_pane_lines(
     sep = "\x1f"
     agents: list[AgentInfo] = []
 
-    for raw_line in raw_output.strip().splitlines():
-        # tmux <3.5 escapes 0x1F to literal \037
-        raw_line = raw_line.replace("\\037", sep)
+    # Pre-join continuation lines caused by
+    # newlines inside tmux variables (e.g.
+    # multiline @pilot-desc). A valid pane line
+    # has >=13 separators (14 fields). When a
+    # line has fewer, it is either a
+    # continuation of the previous line's
+    # multiline field, or the start of a
+    # broken entry. We accumulate until the
+    # total separator count is sufficient.
+    raw_lines: list[str] = []
+    for line in raw_output.strip().splitlines():
+        line = line.replace("\\037", sep)
+        if (
+            raw_lines
+            and raw_lines[-1].count(sep) < 13
+        ):
+            raw_lines[-1] += " " + line
+        else:
+            raw_lines.append(line)
+
+    for raw_line in raw_lines:
         parts = raw_line.split(sep)
         if len(parts) < 7:
             continue

--- a/scripts/new-agent.sh
+++ b/scripts/new-agent.sh
@@ -261,7 +261,7 @@ if [[ -n "$TMUX" ]]; then
     tmux_cmd=$(printf '%q ' "${cmd_args[@]}")
     tmux new-session -d -s "$session_name" \
       -c "$dir" "$tmux_cmd"
-    desc="${prompt:0:80}"
+    desc=$(tr '\n' ' ' <<< "${prompt:0:80}")
     tmux set-option -p -t "$session_name" @pilot-desc "$desc"
     tmux set-option -p -t "$session_name" @pilot-agent "$agent"
     tmux switch-client -t "$session_name"

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -135,7 +135,7 @@ path_prefix='PATH="$HOME/.local/bin:$HOME/bin:$HOME/go/bin:$PATH"'
 if [[ "$agent" == "claude" ]]; then
   path_prefix="export CLAUDE_CODE_DISABLE_AUTOCOMPLETE=true; export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false; $path_prefix"
 fi
-desc="${prompt:0:80}"
+desc=$(tr '\n' ' ' <<< "${prompt:0:80}")
 
 if [[ "$mode" == "remote-tmux" ]]; then
   # Fully remote: create a tmux session on the remote host via SSH


### PR DESCRIPTION
## Summary
- Strip newlines from `@pilot-desc` in `spawn.sh` and `new-agent.sh` to prevent multiline values
- Add defensive line-joining in `parse_pane_lines()` — accumulates physical lines until separator count reaches the expected 13, handling existing multiline fields gracefully

## Problem
When `@pilot-desc` contains newlines (from multi-line spawn prompts), `tmux list-panes` output splits across physical lines. The line-based parser treats each line as a separate pane entry, causing field misalignment — session names appear in wrong columns, agents show as unowned.