### PR TITLE
Add --agent-args for extra CLI flags

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -67,6 +67,7 @@ def spawn_agent(
     owner: str | None = None,
     tier: str | None = None,
     trust: str | None = None,
+    agent_args: str | None = None,
 ) -> str:
     """Create a new AI agent in its own tmux session.
 
@@ -84,6 +85,8 @@ def spawn_agent(
                (e.g. remote MCP) and the caller knows its own pane ID.
         tier: Optional tier label (string). Sets @pilot-tier pane variable.
         trust: Optional trust level (string). Sets @pilot-trust pane variable.
+        agent_args: Optional extra CLI arguments passed to the agent binary
+                    (e.g. "--subtree-only --no-show-model-warnings" for aider).
     """
     # Explicit owner overrides auto-detection.
     # Fall back to $TMUX_PANE (works when the MCP
@@ -110,6 +113,8 @@ def spawn_agent(
         cmd += ["--tier", tier]
     if trust:
         cmd += ["--trust", trust]
+    if agent_args:
+        cmd += ["--agent-args", agent_args]
 
     result = _run(cmd)
     if result.returncode != 0:

--- a/scripts/_agents.sh
+++ b/scripts/_agents.sh
@@ -7,16 +7,24 @@ KNOWN_AGENTS="claude gemini aider codex goose interpreter vibe"
 
 # Build the command array for launching an agent with a prompt.
 # Sets the caller's cmd_args array.
+#
+# Args:
+#   $1 - agent name
+#   $2 - prompt text
+#   $3 - optional extra CLI args (space-separated) appended
+#        before the prompt/message flag. Useful for passing
+#        agent-specific flags like --subtree-only for aider.
 agent_build_cmd() {
-  local agent="$1" prompt="$2"
+  local agent="$1" prompt="$2" extra_args="${3:-}"
+  # shellcheck disable=SC2086
   case "$agent" in
     gemini)      cmd_args=(bash -lc 'exec gemini -y "$0"' "$prompt") ;;
     vibe)        cmd_args=(vibe --prompt "$prompt") ;;
-    aider)       cmd_args=(bash -lc 'exec aider --message "$0"' "$prompt") ;;
+    aider)       cmd_args=(bash -lc "exec aider $extra_args --message \"\$0\"" "$prompt") ;;
     goose)       cmd_args=(goose run "$prompt") ;;
     interpreter) cmd_args=(interpreter --message "$prompt") ;;
-    claude)      cmd_args=(env CLAUDE_CODE_DISABLE_AUTOCOMPLETE=true CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude "$prompt") ;;
-    *)           cmd_args=("$agent" "$prompt") ;;
+    claude)      cmd_args=(env CLAUDE_CODE_DISABLE_AUTOCOMPLETE=true CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude $extra_args "$prompt") ;;
+    *)           cmd_args=("$agent" $extra_args "$prompt") ;;
   esac
 }
 

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -6,7 +6,7 @@
 #   spawn.sh --agent <name> --prompt <text> --dir <path> [--session <name>]
 #            [--host <hostname>] [--mode local-ssh|remote-tmux]
 #            [--owner <session-name>] [--tier <string>]
-#            [--trust <string>]
+#            [--trust <string>] [--agent-args <string>]
 #
 # Outputs the session name to stdout on success.
 set -euo pipefail
@@ -16,18 +16,19 @@ source "$CURRENT_DIR/_agents.sh"
 source "$CURRENT_DIR/_hosts.sh"
 
 agent="" prompt="" dir="" session_override="" host="" mode="" owner=""
-tier="" trust=""
+tier="" trust="" agent_args=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --agent)   agent="$2"; shift 2 ;;
-    --prompt)  prompt="$2"; shift 2 ;;
-    --dir)     dir="$2"; shift 2 ;;
-    --session) session_override="$2"; shift 2 ;;
-    --host)    host="$2"; shift 2 ;;
-    --mode)    mode="$2"; shift 2 ;;
-    --owner)   owner="$2"; shift 2 ;;
-    --tier)    tier="$2"; shift 2 ;;
-    --trust)   trust="$2"; shift 2 ;;
+    --agent)      agent="$2"; shift 2 ;;
+    --prompt)     prompt="$2"; shift 2 ;;
+    --dir)        dir="$2"; shift 2 ;;
+    --session)    session_override="$2"; shift 2 ;;
+    --host)       host="$2"; shift 2 ;;
+    --mode)       mode="$2"; shift 2 ;;
+    --owner)      owner="$2"; shift 2 ;;
+    --tier)       tier="$2"; shift 2 ;;
+    --trust)      trust="$2"; shift 2 ;;
+    --agent-args) agent_args="$2"; shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -74,7 +75,7 @@ fi
 
 # Build agent command
 cmd_args=()
-agent_build_cmd "$agent" "$prompt"
+agent_build_cmd "$agent" "$prompt" "$agent_args"
 
 # Generate session name (same algorithm as new-agent.sh)
 if [[ -n "$session_override" ]]; then


### PR DESCRIPTION
## Summary
- Add optional `--agent-args` parameter to `spawn.sh` and `agent_build_cmd()`
- Thread through MCP `spawn_agent()` as `agent_args` parameter
- Extra args are inserted before the prompt/message flag in the agent command
- Backward compatible — defaults to empty string, no behavior change for existing spawns

## Use case
Agents like aider need extra CLI flags for specific environments:
```
spawn_agent(
  agent="aider",
  prompt="Fix the bug",
  directory="/path/to/worktree/module",
  agent_args="--subtree-only --no-show-model-warnings"
)
```

This avoids hardcoding environment-specific flags in `_agents.sh` while keeping the generic spawn flow clean.

## Test plan
- [x] All 34 existing tests pass
- [x] `agent_build_cmd` with empty args produces identical output to before
- [x] `agent_build_cmd "aider" "prompt" "--subtree-only"` produces correct command