### PR TITLE
Fix Vibe spawn to use interactive mode

### DIFF
--- a/scripts/_agents.sh
+++ b/scripts/_agents.sh
@@ -19,7 +19,7 @@ agent_build_cmd() {
   # shellcheck disable=SC2086
   case "$agent" in
     gemini)      cmd_args=(bash -lc 'exec gemini -y "$0"' "$prompt") ;;
-    vibe)        cmd_args=(vibe --prompt "$prompt") ;;
+    vibe)        cmd_args=(vibe --agent auto-approve "$prompt") ;;
     aider)       cmd_args=(bash -lc "exec aider $extra_args --message \"\$0\"" "$prompt") ;;
     goose)       cmd_args=(goose run "$prompt") ;;
     interpreter) cmd_args=(interpreter --message "$prompt") ;;


### PR DESCRIPTION
The `--prompt` flag runs Vibe in programmatic mode (execute and exit).
Change to positional PROMPT arg with `--agent auto-approve` for
interactive sessions that stay alive in tmux panes.