### PR TITLE
Deck v2: grouped layout, type column, new status icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -21,63 +21,69 @@ Each agent gets its own tmux session. The session name is derived from the promp
 
 ### Agent deck (`prefix+e`)
 
-An fzf-based popup listing all panes across all sessions, sorted by most recent activity, with a live preview of each pane's output. Column widths adapt dynamically to the terminal size.
+An fzf-based popup listing all panes (local and remote) with type, status, CPU, and memory. Sorted alphabetically by session with owner-based grouping. Repeated session and agent names are dimmed for readability.
 
-Columns: **Session:Index** | **Cmd.Pane** | **Status** | **Age** | **CPU** | **RAM**
+Columns: **Pane** | **Type** | **Status** | **CPU** | **MEM**
 
-CPU and RAM are computed per pane by summing the entire process tree (shell + agent + child processes), so you can spot runaway agents at a glance. Status icons show at a glance which agents need attention (see [Status enum](#status-enum)).
+- **Pane**: session name, with window/pane index for multi-pane sessions
+- **Type**: icon + agent name (`🤖 claude`, `⚙ daemon`, `$` shell)
+- **Status**: merged from `@pilot-status` (if set by external tools) or output-age heuristic
+- **CPU/MEM**: summed across the entire process tree per pane
+
+Orchestrator panes are marked with `★`, peer orchestrators with `★⇄`. Panes owned by an orchestrator are grouped under that orchestrator's section. Remote panes (fetched via SSH) appear in a separate host section.
 
 Example:
 
 ```
-┌──────────────────────────────────────────────┬──────────────────────────────────────────────┐
-│ Enter=attach  Ctrl-e/y=scroll                │ PANE:    cld-fix-login:0.0  active           │
-│ Ctrl-d/u=page  Ctrl-w=wrap  Alt-l=log        │ TITLE:   * fix-login-flow                    │
-│ Alt-d=diff  Alt-s=commit  Alt-x=kill         │ WINDOW:  claude                              │
-│ Alt-p=pause  Alt-r=resume  Alt-y=approve     │ DESC:    Fix OAuth callback handling #42     │
-│ Alt-n=new  Alt-e=desc  Alt-y=approve         │ STATUS:  ▶️ working                           │
-│                                              │ WORKDIR: ~/projects/myapp                    │
-│ ─────────────────────────────────────────    │ CMD:     claude  uptime:31m                  │
-│ SESSION           CMD      STAT AGE  CPU MEM │ VCS:     git:fix-login (+2 ~1) ↑1            │
-│▌cld-fix-login:0   claude.0 ▶️   act  31% 2.1G│ ──────────────┤ PREVIEW ├───────────────────  │
-│ gem-refactor-au:0 gemini.0 ▶️   3m   5%  826M│ I'll fix the OAuth callback handling.        │
-│ aider-docs:0      aider.0  ✅   8m   0%  412M│ Let me look at the auth module first...      │
-│ cld-issue-42:0    claude.0 ✋   15m  0%  1.3G│                                              │
-│ app:0             zsh.0         2h   0%  106M│ $ git diff src/auth/callback.ts              │
-│                                              │ + if (!state) return redirect('/login')       │
-│                                              │ - if (!state) throw new Error('missing')      │
-│                                              │                                              │
-│                                              │ Fixed. Running tests now...                  │
-│                                              │ $ npm test                                   │
-│                                              │ PASS  src/auth/callback.test.ts (3 tests)    │
-└──────────────────────────────────────────────┴──────────────────────────────────────────────┘
+PANE                  TYPE           ST  CPU   MEM
+──────────────────────────────────────────────────
+api-server            🤖 claude      ▶   5%  1.2G
+frontend              🤖 vibe        ·   0%  236M
+shell                  $                 0%   62M
+
+── my-orch (2 agents) ────────────────────────
+my-orch           ★   🤖 claude      ▶   1%  800M
+my-orch.1              $             ▶   0%   90M
+task-42               🤖 gemini      ⧖  45%  512M
+task-99               🤖 vibe        !  23%  348M
+
+── server01 ──────────────────────────────────
+ci-runner@server01    🤖 gemini      ⧖
+worker@server01       🤖 vibe        !
 ```
 
 | Key | Action |
 |-----|--------|
-| `Enter` | Attach to selected pane |
+| `Enter` | Attach to pane (SSH for remote) |
+| `Ctrl+R` | Refresh preview |
 | `Ctrl+E` / `Ctrl+Y` | Scroll preview (line) |
 | `Ctrl+D` / `Ctrl+U` | Scroll preview (half-page) |
 | `Ctrl+W` | Toggle line wrap in preview |
-| `Alt+D` | Git diff popup for that pane's directory |
-| `Alt+S` | Commit + push worktree (WIP commit) |
-| `Alt+X` | Kill pane + cleanup worktree (permanent, cannot resume) |
-| `Alt+P` | Pause agent (sends `/exit`, keeps pane alive for resume) |
-| `Alt+R` | Resume agent (sends `claude --continue`, only works after pause) |
+| `Alt+D` | Git diff popup |
+| `Alt+S` | Commit + push worktree |
+| `Alt+X` | Kill pane + cleanup worktree |
+| `Alt+P` | Pause agent (sends `Escape`) |
+| `Alt+R` | Resume agent (sends `resume`) |
 | `Alt+N` | Launch new agent |
 | `Alt+E` | Edit session description |
-| `Alt+Y` | Approve (send Enter to selected pane) |
-| `Alt+L` | View watchdog log |
+| `Alt+Y` | Approve (send Enter to pane) |
+| `Alt+T` | Change pane type (shell/agent/daemon) |
+| `Alt+U` | Copy pane UUID to clipboard |
+| `Alt+L` | View log |
 | `Esc` | Close deck |
 
-The preview panel (right side, 60%) shows metadata for the selected pane:
+The preview panel (right side, 60%) shows metadata:
 
-- **PANE** — target, window name, last activity
-- **TITLE** — pane title (set by the agent)
-- **DESC** — session description (auto-set from prompt, or manually via `@pilot-desc`)
-- **WORKDIR** — working directory (full path, wraps if long)
-- **CMD** — running command and uptime
-- **VCS** — branch, dirty status (+staged ~modified ?untracked), ahead/behind remote (↑↓)
+- **SES/WIN/PANE/UUID** — session, window, pane index, pane ID, UUID
+- **CMD** — running command with runtime (e.g. `vibe (Python)`), agent name if different
+- **DESC** — task description (auto-set from prompt)
+- **STATUS** — merged status with owner and tier
+- **PID/CPU/MEM/UP** — process info
+- **ISSUE/TRUST** — task metadata
+- **HOST/MODE** — remote host and execution mode
+- **WORKDIR/VCS** — working directory and git status
+
+All fields are shown only when set — empty fields are hidden.
 
 ### VCS status (`prefix+d`)
 
@@ -188,33 +194,44 @@ tmux-pilot will display in the deck.
 
 | Variable | Set by | Read by | Values |
 |----------|--------|---------|--------|
-| `@pilot-agent` | spawn.sh | deck, monitor | claude, gemini, ... |
+| `@pilot-uuid` | pilot.tmux (auto) | deck, spawn | Unique pane identifier (12-char hex) |
+| `@pilot-agent` | spawn.sh, auto-detect | deck, monitor | claude, gemini, vibe, ... |
 | `@pilot-desc` | spawn.sh, agent | deck | Task description |
 | `@pilot-workdir` | agent hook | deck, kill.sh | Current dir |
 | `@pilot-status` | external tool, deck | deck | Status enum (see below) |
-| `@pilot-owner` | spawn.sh (MCP) | deck, transfer_ownership | Orchestrator session name that spawned this agent |
+| `@pilot-type` | spawn.sh, Alt+T | deck | shell, agent, daemon |
+| `@pilot-owner` | spawn.sh (MCP) | deck | Pane ID of the orchestrator |
+| `@pilot-owner-uuid` | spawn.sh (remote) | deck | UUID of the owner (cross-machine) |
+| `@pilot-issue` | spawn.sh (MCP) | deck | Issue number |
+| `@pilot-tier` | spawn.sh (MCP) | deck | Tier label |
+| `@pilot-trust` | spawn.sh (MCP) | deck | Trust level |
 | `@pilot-needs-help` | external tool | deck | "" or description |
-| `@pilot-review-target` | orchestrator | external tool | Pane target for review notifications |
-| `@pilot-review-context` | orchestrator | external tool | Task-specific review hints for the worker |
+| `@pilot-review-target` | orchestrator | external tool | Pane target for reviews |
+| `@pilot-review-context` | orchestrator | external tool | Task-specific review hints |
+| `@pilot-worktree` | spawn.sh (MCP) | deck | Worktree path |
+| `@pilot-repo` | spawn.sh (MCP) | deck | Repo root path |
+
+`@pilot-uuid` is assigned automatically to every pane on tmux startup and when new panes are created. It provides a stable identity that survives pane reordering (unlike `%NNN` pane IDs which tmux can reassign).
 
 ### Status enum
 
 `@pilot-status` accepts a fixed set of values. The deck renders each as an emoji icon in the list and shows the raw value in the preview panel.
 
-| Value | Emoji | ASCII | Meaning |
-|-------|-------|-------|---------|
-| `working` | ▶️ | `●` green | Agent is actively running |
-| `watching` | 👀 | `◉` blue | Watchdog is monitoring this pane |
-| `waiting` | ✋ | `⚠` yellow | Needs human attention |
-| `paused` | ⏸️ | `‖` gray | Intentionally suspended (via pause) |
-| `done` | ✅ | `✔` green | Task completed |
-| *(empty)* | | | No status — non-agent pane or untracked |
+| Value | Icon | Meaning |
+|-------|------|---------|
+| `working` | `▶` | Agent is actively running |
+| `watching` | `▶` | Being monitored |
+| `waiting` | `!` | Needs human attention |
+| `paused` | `‖` | Suspended (via pause) |
+| `done` | `✓` | Task completed |
+| `stuck` | `!` | Agent is stuck |
+| *(empty)* | `·` | Idle, or derived from output age |
 
-Unknown values are rendered as a blank space. Set `@pilot-status-ascii "1"` in your `tmux.conf` to use BMP symbols with ANSI colors instead of emojis.
+When `@pilot-status` is not set, the deck uses a heuristic based on the pane's last output time: recent output (`< 60s`) shows `▶`, older shows `·`. This ensures meaningful status for panes not managed by external tools.
 
-External tools (watchdog daemons, orchestrators) write `@pilot-status` to communicate agent state. The deck also sets it automatically on pause (`paused`) and resume (`working`).
+External tools (monitoring daemons, orchestrators) write `@pilot-status` to communicate agent state. The deck sets it on pause (`paused`) and resume (`working`).
 
-When `@pilot-needs-help` is set, the deck displays the `waiting` icon regardless of `@pilot-status`, and the preview shows the help description.
+When `@pilot-needs-help` is set, `!` is shown regardless of `@pilot-status`.
 
 ```bash
 # Examples

--- a/mcp/agents.py
+++ b/mcp/agents.py
@@ -36,6 +36,7 @@ class AgentInfo:
     cpu: str = ""
     memory: str = ""
     session: str = ""
+    pane_id: str = ""
 
 
 def _run(
@@ -175,7 +176,7 @@ def parse_pane_lines(
         if len(parts) < 7:
             continue
         # Pad to expected field count
-        while len(parts) < 19:
+        while len(parts) < 21:
             parts.append("")
         (
             target, agent, desc, workdir, path,
@@ -183,8 +184,8 @@ def parse_pane_lines(
             pstatus, powner, ptier, ptrust,
             preview_target, preview_context,
             pissue, pworktree, prepo,
-            session,
-        ) = parts[:19]
+            session, pane_id,
+        ) = parts[:21]
 
         directory = workdir if workdir else path
 
@@ -210,6 +211,7 @@ def parse_pane_lines(
 
         agents.append(AgentInfo(
             target=target,
+            pane_id=pane_id,
             agent=agent or "",
             desc=desc,
             workdir=directory,
@@ -239,7 +241,8 @@ def parse_pane_lines(
 # Consumers can use this directly or call
 # list_agent_panes() which handles everything.
 PANE_FORMAT_FIELDS = [
-    "#{session_name}:#{window_index}.#{pane_index}",
+    "#{session_name}:#{window_index}"
+    ".#{pane_index}",
     "#{@pilot-agent}",
     "#{@pilot-desc}",
     "#{@pilot-workdir}",
@@ -258,6 +261,7 @@ PANE_FORMAT_FIELDS = [
     "#{@pilot-worktree}",
     "#{@pilot-repo}",
     "#{session_name}",
+    "#{pane_id}",
 ]
 
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -174,6 +174,35 @@ def list_agents() -> str:
         issue_info = (
             f"  issue={a.issue}" if a.issue else ""
         )
+        status_info = (
+            f"  status={a.status}" if a.status else ""
+        )
+        owner_info = (
+            f"  owner={a.owner}" if a.owner else ""
+        )
+        tier_info = (
+            f"  tier={a.tier}" if a.tier else ""
+        )
+        trust_info = (
+            f"  trust={a.trust}" if a.trust else ""
+        )
+        review_target_info = (
+            f"  review_target={a.review_target}"
+            if a.review_target else ""
+        )
+        review_context_info = (
+            f"  review_ctx={a.review_context}"
+            if a.review_context else ""
+        )
+        worktree_info = (
+            f"  worktree={a.worktree}" if a.worktree else ""
+        )
+        repo_info = (
+            f"  repo={a.repo}" if a.repo else ""
+        )
+        pane_id_info = (
+            f"  pane_id={a.pane_id}" if a.pane_id else ""
+        )
         entry = (
             f"  {a.target}"
             f"  agent={a.agent or '?'}"
@@ -182,8 +211,17 @@ def list_agents() -> str:
             f"  age={a.age}"
             f"  cpu={a.cpu}"
             f"  mem={a.memory}"
+            f"{pane_id_info}"
             f"{host_info}"
             f"{issue_info}"
+            f"{status_info}"
+            f"{owner_info}"
+            f"{tier_info}"
+            f"{trust_info}"
+            f"{review_target_info}"
+            f"{review_context_info}"
+            f"{worktree_info}"
+            f"{repo_info}"
         )
         lines.append(entry)
 

--- a/pilot.tmux
+++ b/pilot.tmux
@@ -50,3 +50,39 @@ tmux bind-key "$key_vcs" display-popup \
 if [ -n "$key_dash" ] && [ -n "$dash_cmd" ]; then
   tmux bind-key "$key_dash" run-shell "$dash_cmd"
 fi
+
+# Assign UUIDs to all panes that don't have one.
+# Runs on startup and via hook on new panes.
+assign_oid='
+  target="#{session_name}:#{window_index}.#{pane_index}"
+  oid=$(tmux display-message -t "$target" \
+    -p "#{@pilot-uuid}" 2>/dev/null)
+  if [ -z "$oid" ]; then
+    oid=$(uuidgen | tr "[:upper:]" "[:lower:]" \
+      | cut -c1-12)
+    tmux set-option -p -t "$target" \
+      @pilot-uuid "$oid" 2>/dev/null
+  fi
+'
+
+# Assign to all existing panes
+tmux list-panes -a -F \
+  '#{session_name}:#{window_index}.#{pane_index}' |
+while read -r t; do
+  oid=$(tmux display-message -t "$t" \
+    -p '#{@pilot-uuid}' 2>/dev/null) || oid=""
+  if [ -z "$oid" ]; then
+    oid=$(uuidgen | tr '[:upper:]' '[:lower:]' \
+      | cut -c1-12)
+    tmux set-option -p -t "$t" \
+      @pilot-uuid "$oid" 2>/dev/null || true
+  fi
+done
+
+# Auto-assign on new pane creation
+tmux set-hook -g after-split-window \
+  "run-shell '$assign_oid'"
+tmux set-hook -g after-new-window \
+  "run-shell '$assign_oid'"
+tmux set-hook -g after-new-session \
+  "run-shell '$assign_oid'"

--- a/scripts/_agents.sh
+++ b/scripts/_agents.sh
@@ -6,6 +6,46 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Single source of truth for supported agent names.
 KNOWN_AGENTS="claude gemini aider codex goose interpreter vibe"
 
+# Check if an agent binary is available.
+# Searches PATH, npm global bin, nvm, and common
+# install locations.
+agent_available() {
+  local name="$1"
+  command -v "$name" &>/dev/null && return 0
+  local npm_bin
+  npm_bin=$(npm bin -g 2>/dev/null) || npm_bin=""
+  [[ -n "$npm_bin" && -x "$npm_bin/$name" ]] \
+    && return 0
+  for d in \
+    "$HOME/.nvm/versions/node"/*/bin \
+    /usr/local/bin \
+    "$HOME/.local/bin" \
+    "$HOME/.cargo/bin"; do
+    [[ -x "$d/$name" ]] && return 0
+  done
+  return 1
+}
+
+# List all available agents (known + user-configured).
+list_available_agents() {
+  local agents=""
+  for name in $KNOWN_AGENTS; do
+    agent_available "$name" \
+      && agents+="${name}"$'\n'
+  done
+  local extra
+  extra="${PILOT_EXTRA_AGENTS:-}"
+  if [[ -z "$extra" ]]; then
+    extra=$(tmux show-option -gqv \
+      @pilot-extra-agents 2>/dev/null) || true
+  fi
+  for name in $extra; do
+    agent_available "$name" \
+      && agents+="${name}"$'\n'
+  done
+  printf '%s' "${agents%$'\n'}" | sort
+}
+
 source "$CURRENT_DIR/_keys.sh"
 
 # Build the command array for launching an agent with a prompt.
@@ -38,30 +78,23 @@ _send_text() {
 }
 
 # Send the appropriate stop command to a pane.
+# Pause: send Escape to interrupt the agent without
+# killing it. The agent stays alive with full context.
 agent_pause() {
   local target="$1" agent="$2"
-  case "$agent" in
-    claude)      _send_text "$target" '/exit' ;;
-    gemini)      _send_text "$target" '/quit' ;;
-    vibe)        _send_text "$target" '/exit' ;;
-    aider)       _send_text "$target" '/exit' ;;
-    goose)       tmux send-keys -t "$target" C-d ;;
-    *)           tmux send-keys -t "$target" C-c ;;
-  esac
-  tmux set-option -p -t "$target" @pilot-status "paused" 2>/dev/null || true
+  tmux send-keys -t "$target" Escape
+  tmux set-option -p -t "$target" \
+    @pilot-status "paused" 2>/dev/null || true
 }
 
-# Send the appropriate resume/restart command to a pane.
+# Resume: send "resume" to the agent. All agents
+# understand this as a natural language instruction
+# to continue their previous task.
 agent_resume() {
   local target="$1" agent="$2"
-  tmux set-option -p -t "$target" @pilot-status "working" 2>/dev/null || true
-  case "$agent" in
-    claude)      _send_text "$target" 'claude --continue' ;;
-    gemini)      _send_text "$target" "bash -lc 'gemini -y'" ;;
-    vibe)        _send_text "$target" 'vibe' ;;
-    goose)       _send_text "$target" 'goose session resume' ;;
-    *)           _send_text "$target" "$agent" ;;
-  esac
+  tmux set-option -p -t "$target" \
+    @pilot-status "working" 2>/dev/null || true
+  _send_text "$target" 'resume'
 }
 
 # Detect which agent is running in a pane.
@@ -75,25 +108,62 @@ detect_agent() {
     printf '%s' "$agent"
     return
   fi
-  # Fallback: walk the full process tree under the pane PID
-  # and match command names against known agents.
+  # Check pane_start_command for agent name
+  local start_cmd
+  start_cmd=$(tmux display-message -t "$target" \
+    -p '#{pane_start_command}' 2>/dev/null) \
+    || start_cmd=""
+  if [[ -n "$start_cmd" ]]; then
+    for name in $KNOWN_AGENTS; do
+      if [[ "$start_cmd" == *"$name"* ]]; then
+        printf '%s' "$name"
+        return
+      fi
+    done
+  fi
+
+  # Fallback: walk the full process tree under the
+  # pane PID and match against known agents.
+  # Checks both the binary name (comm) and the full
+  # command line (args) — catches agents launched
+  # via runtime wrappers (node, python3, bash).
   local pane_pid
-  pane_pid=$(tmux display-message -t "$target" -p '#{pane_pid}' 2>/dev/null) || return 1
-  agent=$(ps -ax -o pid=,ppid=,comm= | awk \
+  pane_pid=$(tmux display-message -t "$target" \
+    -p '#{pane_pid}' 2>/dev/null) || return 1
+  agent=$(ps -ax -o pid=,ppid=,args= | awk \
     -v root="$pane_pid" \
     -v agents="$KNOWN_AGENTS" '
-    { ppid[$1]=$2; comm[$1]=$3 }
+    {
+      ppid[$1]=$2
+      # args= includes the full command line
+      cmd=""
+      for (i=3; i<=NF; i++) cmd=cmd " " $i
+      args[$1]=cmd
+      # Extract just the binary name
+      split($3, parts, "/")
+      comm[$1]=parts[length(parts)]
+    }
     END {
       pids[root]=1; changed=1
       while (changed) {
         changed=0
         for (p in ppid)
-          if (!(p in pids) && ppid[p] in pids) { pids[p]=1; changed=1 }
+          if (!(p in pids) && ppid[p] in pids) {
+            pids[p]=1; changed=1
+          }
       }
       n=split(agents, names, " ")
       for (p in pids)
-        for (i=1; i<=n; i++)
-          if (comm[p] == names[i]) { print names[i]; exit }
+        for (i=1; i<=n; i++) {
+          if (comm[p] == names[i]) {
+            print names[i]; exit
+          }
+          # Check full args for agent name
+          # (e.g. node /path/to/gemini/cli.js)
+          if (index(args[p], names[i]) > 0) {
+            print names[i]; exit
+          }
+        }
     }')
   if [[ -n "$agent" ]]; then
     printf '%s' "$agent"

--- a/scripts/_preview.sh
+++ b/scripts/_preview.sh
@@ -23,12 +23,83 @@ fi
 
 # Look up target and path from the data file by line number
 line=$(sed -n "${idx}p" "$data_file")
-target="${line%%	*}"
-path="${line#*	}"
+IFS=$'\t' read -r target path host <<< "$line"
 
 if [[ -z "$target" ]]; then
   echo "no pane at index $idx"
   exit 1
+fi
+
+# Remote pane: fetch metadata + content via SSH
+if [[ -n "$host" ]]; then
+  session="${target%%:*}"
+  D="@@@"
+  # Single SSH: metadata + pane capture
+  remote_data=$(ssh \
+    -o ConnectTimeout=2 -o BatchMode=yes \
+    "$host" "
+    tmux display-message -t '$target' -p \
+      '#{window_name}${D}#{@pilot-agent}${D}#{@pilot-desc}${D}#{@pilot-status}${D}#{@pilot-tier}${D}#{@pilot-trust}${D}#{@pilot-owner}${D}#{@pilot-owner-session}${D}#{@pilot-issue}${D}#{@pilot-worktree}${D}#{@pilot-repo}${D}#{@pilot-review-target}${D}#{@pilot-review-context}${D}#{pane_current_command}${D}#{pane_current_path}' 2>/dev/null
+    echo '${D}CAPTURE${D}'
+    tmux capture-pane -t '$target' -p -S -50 \
+      2>/dev/null
+  " 2>/dev/null) || {
+    echo "(could not reach $host)"
+    exit 0
+  }
+
+  # Split metadata from capture
+  meta="${remote_data%%${D}CAPTURE${D}*}"
+  capture="${remote_data#*${D}CAPTURE${D}}"
+
+  # Parse metadata
+  IFS="$D" read -r r_window r_agent r_desc \
+    r_status r_tier r_trust r_owner \
+    r_owner_ses r_issue r_worktree r_repo \
+    r_review_target r_review_ctx \
+    r_cmd r_path \
+    <<< "$meta"
+
+  # Display header
+  printf '\033[1mTARGET:\033[0m  %s@%s\n' \
+    "$target" "$host"
+  printf '\033[1mWINDOW:\033[0m  %s\n' \
+    "${r_window:-—}"
+  printf '\033[1mPATH:\033[0m    %s\n' \
+    "${r_path:-—}"
+  printf '\033[1mCOMMAND:\033[0m %s\n' \
+    "${r_cmd:-—}"
+  [[ -n "$r_agent" ]] && \
+    printf '\033[1mAGENT:\033[0m   %s\n' "$r_agent"
+  [[ -n "$r_desc" ]] && \
+    printf '\033[1mDESC:\033[0m    %s\n' "$r_desc"
+  [[ -n "$r_status" ]] && \
+    printf '\033[1mSTATUS:\033[0m  %s\n' "$r_status"
+  [[ -n "$r_tier" ]] && \
+    printf '\033[1mTIER:\033[0m    %s\n' "$r_tier"
+  [[ -n "$r_trust" ]] && \
+    printf '\033[1mTRUST:\033[0m   %s\n' "$r_trust"
+  [[ -n "$r_owner_ses" ]] && \
+    printf '\033[1mOWNER:\033[0m   %s\n' \
+      "$r_owner_ses"
+  [[ -n "$r_issue" ]] && \
+    printf '\033[1mISSUE:\033[0m   %s\n' "$r_issue"
+  [[ -n "$r_worktree" ]] && \
+    printf '\033[1mWORKTR:\033[0m  %s\n' \
+      "$r_worktree"
+  [[ -n "$r_repo" ]] && \
+    printf '\033[1mREPO:\033[0m    %s\n' "$r_repo"
+  [[ -n "$r_review_target" ]] && \
+    printf '\033[1mREVIEW:\033[0m  %s\n' \
+      "$r_review_target"
+  [[ -n "$r_review_ctx" ]] && \
+    printf '\033[1mREV CTX:\033[0m %s\n' \
+      "$r_review_ctx"
+
+  printf '─%.0s' {1..40}
+  printf '\n'
+  printf '%s\n' "$capture"
+  exit 0
 fi
 
 # Compact path: replace $HOME with ~
@@ -44,9 +115,37 @@ pane_start=$(tmux display-message -t "$target" -p '#{pane_start_command}' 2>/dev
 desc=$(tmux display-message -t "$target" -p '#{@pilot-desc}' 2>/dev/null) || desc=""
 pilot_host=$(tmux display-message -t "$target" -p '#{@pilot-host}' 2>/dev/null) || pilot_host=""
 pilot_mode=$(tmux display-message -t "$target" -p '#{@pilot-mode}' 2>/dev/null) || pilot_mode=""
-pilot_owner=$(tmux display-message -t "$target" -p '#{@pilot-owner}' 2>/dev/null) || pilot_owner=""
+# Resolve owner to "name (uuid)" format
+pilot_owner=""
+_raw_owner=$(tmux display-message -t "$target" \
+  -p '#{@pilot-owner}' 2>/dev/null) \
+  || _raw_owner=""
+if [[ -n "$_raw_owner" ]]; then
+  _owner_name=$(tmux display-message \
+    -t "$_raw_owner" \
+    -p '#{session_name}' 2>/dev/null) \
+    || _owner_name=""
+  _owner_uuid=$(tmux display-message \
+    -t "$_raw_owner" \
+    -p '#{@pilot-uuid}' 2>/dev/null) \
+    || _owner_uuid=""
+  if [[ -n "$_owner_name" && -n "$_owner_uuid" ]]; then
+    pilot_owner="${_owner_name} (${_owner_uuid})"
+  elif [[ -n "$_owner_name" ]]; then
+    pilot_owner="$_owner_name"
+  else
+    pilot_owner="$_raw_owner"
+  fi
+fi
 pilot_status=$(tmux display-message -t "$target" -p '#{@pilot-status}' 2>/dev/null) || pilot_status=""
 pilot_needs_help=$(tmux display-message -t "$target" -p '#{@pilot-needs-help}' 2>/dev/null) || pilot_needs_help=""
+pilot_tier=$(tmux display-message -t "$target" -p '#{@pilot-tier}' 2>/dev/null) || pilot_tier=""
+pilot_trust=$(tmux display-message -t "$target" -p '#{@pilot-trust}' 2>/dev/null) || pilot_trust=""
+pilot_review_target=$(tmux display-message -t "$target" -p '#{@pilot-review-target}' 2>/dev/null) || pilot_review_target=""
+pilot_review_context=$(tmux display-message -t "$target" -p '#{@pilot-review-context}' 2>/dev/null) || pilot_review_context=""
+pilot_issue=$(tmux display-message -t "$target" -p '#{@pilot-issue}' 2>/dev/null) || pilot_issue=""
+pilot_worktree=$(tmux display-message -t "$target" -p '#{@pilot-worktree}' 2>/dev/null) || pilot_worktree=""
+pilot_repo=$(tmux display-message -t "$target" -p '#{@pilot-repo}' 2>/dev/null) || pilot_repo=""
 
 now=$(date +%s)
 
@@ -124,54 +223,186 @@ if [[ -n "$path" && -d "$path" ]]; then
   fi
 fi
 
-# Preview header — always exactly 10 lines (padded) to match ~10 in deck.sh
-printf '\033[1mPANE:\033[0m    %s  %s\n' "$target" "$age"
-printf '\033[1mTITLE:\033[0m   %s\n' "$title"
-printf '\033[1mWINDOW:\033[0m  %s\n' "$window"
-host_suffix=""
-if [[ -n "$pilot_host" ]]; then
-  host_suffix="  [$pilot_host via $pilot_mode]"
-fi
-if [[ -n "$desc" ]]; then
-  printf '\033[1mDESC:\033[0m    %s%s\n' "$desc" "$host_suffix"
-elif [[ -n "$pilot_host" ]]; then
-  printf '\033[1mHOST:\033[0m    %s (%s)\n' "$pilot_host" "$pilot_mode"
-else
-  printf '\n'
-fi
-if [[ -n "$pilot_owner" ]]; then
-  printf '\033[1mOWNER:\033[0m   %s\n' "$pilot_owner"
-else
-  printf '\n'
-fi
-# Status line: show emoji icon + raw value + needs-help detail
+# Preview header with all metadata fields.
+B=$'\033[1m'
+R=$'\033[0m'
+DM=$'\033[2m'
+
+# Status icon
+# Merged status: semantic (@pilot-status) if set,
+# otherwise output-age heuristic from tmux.
+stat_str=""
 if [[ -n "$pilot_needs_help" ]]; then
-  printf '\033[1;33mSTATUS:\033[0m  ✋ waiting — %s\n' "$pilot_needs_help"
+  stat_str="! waiting — $pilot_needs_help"
 elif [[ -n "$pilot_status" ]]; then
-  USE_ASCII=$(tmux show-option -gqv @pilot-status-ascii 2>/dev/null)
   case "$pilot_status" in
-    working)  [[ "$USE_ASCII" == "1" ]] && icon='\033[32m●\033[0m' || icon='▶️' ;;
-    watching) [[ "$USE_ASCII" == "1" ]] && icon='\033[34m◉\033[0m' || icon='👀' ;;
-    waiting)  [[ "$USE_ASCII" == "1" ]] && icon='\033[33m⚠\033[0m' || icon='✋' ;;
-    paused)   [[ "$USE_ASCII" == "1" ]] && icon='\033[90m‖\033[0m' || icon='⏸️' ;;
-    done)     [[ "$USE_ASCII" == "1" ]] && icon='\033[32m✔\033[0m' || icon='✅' ;;
-    *)        icon='?' ;;
+    working)  si="▶" ;; watching) si="▶" ;;
+    waiting)  si="!" ;; paused)   si="‖" ;;
+    done)     si="✓" ;; stuck)    si="!" ;;
+    *)        si="·" ;;
   esac
-  printf '\033[1mSTATUS:\033[0m  %b %s%s\n' "$icon" "$pilot_status" "$host_suffix"
-else
-  printf '\n'
+  stat_str="$si $pilot_status"
+elif [[ -n "$age" ]]; then
+  case "$age" in
+    active)  stat_str="▶ active" ;;
+    *)       stat_str="· quiet (${age})" ;;
+  esac
 fi
-printf '\033[1mWORKDIR:\033[0m \033[2m%s\033[0m\n' "$display_path"
-cmd_line="$pane_cmd"
-if [[ -n "$uptime_str" ]]; then
-  cmd_line+="  uptime:$uptime_str"
+
+# Compute CPU/MEM from process tree
+cpu_str="" mem_str=""
+if [[ -n "$pane_pid" ]]; then
+  ps_data=$(ps -ax -o pid=,ppid=,rss=,%cpu=)
+  # Sum RSS of process tree
+  mem_kb=$(awk -v root="$pane_pid" '
+    {mem[$1]=$3; parent[$1]=$2}
+    END {
+      pids[root]=1; c=1
+      while(c){c=0; for(p in parent)
+        if(!(p in pids)&&parent[p] in pids)
+          {pids[p]=1;c=1}}
+      for(p in pids) t+=mem[p]
+      print t+0
+    }' <<< "$ps_data")
+  if [[ "$mem_kb" -ge 1048576 ]]; then
+    mem_str=$(printf "%.1fG" \
+      "$(echo "$mem_kb/1048576" | bc -l)")
+  elif [[ "$mem_kb" -ge 1024 ]]; then
+    mem_str="$((mem_kb / 1024))M"
+  else
+    mem_str="${mem_kb}K"
+  fi
+  cpu_str=$(awk -v root="$pane_pid" '
+    {cpu[$1]=$4; parent[$1]=$2}
+    END {
+      pids[root]=1; c=1
+      while(c){c=0; for(p in parent)
+        if(!(p in pids)&&parent[p] in pids)
+          {pids[p]=1;c=1}}
+      for(p in pids) t+=cpu[p]
+      printf "%d%%", t+0
+    }' <<< "$ps_data")
 fi
-printf '\033[1mCMD:\033[0m     %s\n' "$cmd_line"
-if [[ -n "$vcs_info" ]]; then
-  printf '\033[1mVCS:\033[0m     %s\n' "$vcs_info"
-else
-  printf '\n'
+
+# Display
+session="${target%%:*}"
+pane_num="${target#*:}"
+
+# Line 1: identity
+pane_tmux_id=$(tmux display-message -t "$target" \
+  -p '#{pane_id}' 2>/dev/null) || pane_tmux_id=""
+pilot_uuid=$(tmux display-message -t "$target" \
+  -p '#{@pilot-uuid}' 2>/dev/null) || pilot_uuid=""
+printf "${B}SES:${R} %s │ ${B}WIN:${R} %s │ ${B}PANE:${R} %s %s │ ${B}UUID:${R} %s\n" \
+  "$session" "$window" "$pane_num" \
+  "${pane_tmux_id}" "$pilot_uuid"
+
+# Line 2: cmd + agent
+pilot_agent=$(tmux display-message -t "$target" \
+  -p '#{@pilot-agent}' 2>/dev/null) || pilot_agent=""
+# Use start command's first word if current cmd
+# is a runtime (node, python, bash, etc.)
+display_cmd="$pane_cmd"
+case "$pane_cmd" in
+  Python|python*|node|bash|zsh|sh)
+    _start=$(tmux display-message -t "$target" \
+      -p '#{pane_start_command}' 2>/dev/null) \
+      || _start=""
+    if [[ -n "$_start" ]]; then
+      # Find agent name in start command
+      display_cmd=""
+      if [[ -n "$pilot_agent" \
+          && "$_start" == *"$pilot_agent"* ]]; then
+        display_cmd="$pilot_agent"
+      else
+        for _a in claude gemini aider codex \
+            goose interpreter vibe; do
+          if [[ "$_start" == *"$_a"* ]]; then
+            display_cmd="$_a"
+            break
+          fi
+        done
+      fi
+      [[ -z "$display_cmd" ]] \
+        && display_cmd="$pane_cmd"
+    fi
+    ;;
+esac
+if [[ -n "$display_cmd" ]]; then
+  # Show runtime in parens if different from cmd
+  cmd_str="$display_cmd"
+  if [[ "$pane_cmd" != "$display_cmd" ]]; then
+    cmd_str+=" (${pane_cmd})"
+  fi
+  if [[ -n "$pilot_agent" \
+      && "$pilot_agent" != "$display_cmd" ]]; then
+    printf "${B}CMD:${R}      %s │ ${B}AGENT:${R} %s\n" \
+      "$cmd_str" "$pilot_agent"
+  else
+    printf "${B}CMD:${R}      %s\n" "$cmd_str"
+  fi
 fi
+
+# Line 3: desc (if set)
+[[ -n "$desc" ]] && \
+  printf "${B}DESC:${R}     %s\n" "$desc"
+
+# Line 4: status + owner + tier (grouped)
+line4=""
+[[ -n "$stat_str" ]] && \
+  line4+="${B}STATUS:${R} ${stat_str}"
+[[ -n "$pilot_owner" ]] && \
+  line4+=" │ ${B}OWNER:${R} ${pilot_owner}"
+[[ -n "$pilot_tier" ]] && \
+  line4+=" │ ${B}TIER:${R} ${pilot_tier}"
+[[ -n "$line4" ]] && printf '%s\n' "$line4"
+
+# Line 5: process info (grouped)
+line5=""
+if [[ -n "$pane_pid" ]]; then
+  line5+="${B}PID:${R} ${pane_pid}"
+  [[ -n "$cpu_str" ]] && \
+    line5+=" │ ${B}CPU:${R} ${cpu_str}"
+  [[ -n "$mem_str" ]] && \
+    line5+=" │ ${B}MEM:${R} ${mem_str}"
+  [[ -n "$uptime_str" ]] && \
+    line5+=" │ ${B}UP:${R} ${uptime_str}"
+  printf '%s\n' "$line5"
+fi
+
+# Line 6: issue + trust (if set)
+line6=""
+[[ -n "$pilot_issue" ]] && \
+  line6+="${B}ISSUE:${R} ${pilot_issue}"
+[[ -n "$pilot_trust" ]] && \
+  line6+=" │ ${B}TRUST:${R} ${pilot_trust}"
+[[ -n "$line6" ]] && printf '%s\n' "$line6"
+
+# Line 7: host + mode (if set)
+line7=""
+[[ -n "$pilot_host" ]] && \
+  line7+="${B}HOST:${R} ${pilot_host}"
+[[ -n "$pilot_mode" ]] && \
+  line7+=" │ ${B}MODE:${R} ${pilot_mode}"
+[[ -n "$line7" ]] && printf '%s\n' "$line7"
+
+# Optional fields (only when set)
+[[ -n "$pilot_review_target" ]] && \
+  printf "${B}REVIEW:${R}   %s\n" \
+    "$pilot_review_target"
+[[ -n "$pilot_review_context" ]] && \
+  printf "${B}REV CTX:${R}  %s\n" \
+    "$pilot_review_context"
+[[ -n "$pilot_worktree" ]] && \
+  printf "${B}WORKTREE:${R} %s\n" \
+    "$pilot_worktree"
+[[ -n "$pilot_repo" ]] && \
+  printf "${B}REPO:${R}     %s\n" "$pilot_repo"
+[[ -n "$display_path" ]] && \
+  printf "${B}WORKDIR:${R}  ${DM}%s${R}\n" \
+    "$display_path"
+[[ -n "$vcs_info" ]] && \
+  printf "${B}VCS:${R}      %s\n" "$vcs_info"
 preview_w=${FZF_PREVIEW_COLUMNS:-40}
 label="┤ PREVIEW ├"
 label_len=${#label}

--- a/scripts/deck.sh
+++ b/scripts/deck.sh
@@ -10,36 +10,9 @@ set -euo pipefail
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/_agents.sh"
+source "$CURRENT_DIR/_hosts.sh"
 # Unit separator — safe delimiter
 SEP=$'\x1f'
-
-# Status enum → emoji mapping.
-# External tools write semantic values to @pilot-status;
-# the deck renders them as icons.
-# Set @pilot-status-ascii "1" in tmux.conf for BMP fallback.
-USE_ASCII=$(tmux show-option -gqv @pilot-status-ascii 2>/dev/null)
-status_icon() {
-  local raw="$1"
-  if [[ "$USE_ASCII" == "1" ]]; then
-    case "$raw" in
-      working)  printf '\033[32m●\033[0m' ;;  # green
-      watching) printf '\033[34m◉\033[0m' ;;  # blue
-      waiting)  printf '\033[33m⚠\033[0m' ;;  # yellow
-      paused)   printf '\033[90m‖\033[0m' ;;  # gray
-      done)     printf '\033[32m✔\033[0m' ;;  # green
-      *)        printf ' ' ;;
-    esac
-  else
-    case "$raw" in
-      working)  printf '▶️' ;;
-      watching) printf '👀' ;;
-      waiting)  printf '✋' ;;
-      paused)   printf '⏸️' ;;
-      done)     printf '✅' ;;
-      *)        printf ' ' ;;
-    esac
-  fi
-}
 
 # Get human-readable RSS of a process tree.
 # Reads ps output from stdin, takes root PID as $1.
@@ -69,140 +42,111 @@ pane_tree_cpu() {
     }'
 }
 
-# Compute column widths from terminal size.
-# Sets globals: COL_SES COL_PANE COL_STATUS COL_AGE COL_CPU COL_MEM
-compute_layout() {
-  local total_cols popup_w client_w pct
-  # Query tmux directly (tput unreliable during popup PTY init)
-  popup_w=$(tmux show-option -gqv @pilot-popup-deck-width 2>/dev/null)
-  : "${popup_w:=95%}"
-  if [[ "$popup_w" == *% ]]; then
-    client_w=$(tmux display-message -p '#{client_width}' 2>/dev/null) || client_w=120
-    pct=${popup_w%'%'}
-    total_cols=$(( client_w * pct / 100 ))
-  else
-    total_cols=$popup_w
+# Ensure all panes have a UUID (@pilot-uuid)
+tmux list-panes -a \
+  -F '#{session_name}:#{window_index}.#{pane_index} #{@pilot-uuid}' |
+while read -r t oid; do
+  if [[ -z "$oid" ]]; then
+    oid=$(uuidgen | tr '[:upper:]' '[:lower:]' \
+      | cut -c1-12)
+    tmux set-option -p -t "$t" \
+      @pilot-uuid "$oid" 2>/dev/null || true
   fi
-  # List panel: 40% of popup minus fzf chrome (preview gets 60%)
-  local list_w=$(( total_cols * 40 / 100 - 4 ))
+done
 
-  # Fixed-width columns (never truncated)
-  COL_AGE=7    # "active", "5m ago", "12h ago"
-  COL_CPU=4    # "0%", "100%"
-  COL_MEM=5    # "1.3G", "429M"
-  COL_PANE=14  # window_name:win_idx.pane_idx
-  COL_STATUS=4 # status emoji
-  local gaps=10  # column-t 2-space gaps between 6 columns (5 gaps)
-  local fixed=$(( COL_PANE + COL_STATUS + COL_AGE + COL_CPU + COL_MEM + gaps ))
+# Separator for fzf header (fixed width).
+COL_SEP=$(printf '─%.0s' $(seq 1 60))
 
-  # Session column gets whatever space remains after fixed columns
-  COL_SES=$(( list_w - fixed ))
-  if [[ $COL_SES -lt 8 ]]; then COL_SES=8; fi
-}
-compute_layout
-
-# Column header with bold styling (fzf --ansi processes escape codes)
-COL_HEADER=$(printf '\033[1m%-*.*s  %-*.*s  %-*.*s  %-*.*s  %-*.*s  %-*.*s\033[0m' \
-  "$COL_SES" "$COL_SES" "SESSION" "$COL_PANE" "$COL_PANE" "PANE" \
-  "$COL_STATUS" "$COL_STATUS" "STAT" \
-  "$COL_AGE" "$COL_AGE" "AGE" "$COL_CPU" "$COL_CPU" "CPU" "$COL_MEM" "$COL_MEM" "MEM")
-
-# Separator line matching column header width
-COL_SEP_W=$(( COL_SES + COL_PANE + COL_STATUS + COL_AGE + COL_CPU + COL_MEM + 10 ))
-COL_SEP=$(printf '─%.0s' $(seq 1 "$COL_SEP_W"))
-
-# Align pre-truncated columns (column -t handles emoji/wide chars).
-# A ruler row forces column-t to allocate full budgeted widths
-# even when actual data is shorter.
-format_display() {
-  local ruler
-  ruler=$(printf '%*s\t%*s\t%*s\t%*s\t%*s\t%*s' \
-    "$COL_SES" "" "$COL_PANE" "" "$COL_STATUS" "" \
-    "$COL_AGE" "" "$COL_CPU" "" "$COL_MEM" "" | tr ' ' '_')
-  { echo "$ruler"; cat; } | column -t -s$'\t' | tail -n +2
-}
-
-# Build an indexed data file:
-#   line N = target<TAB>path
-# and a display list:
-#   line N = index<TAB>display columns
-# The index is a simple line number — never contains
-# user-controlled data, so it's safe in fzf fields.
-
-list_panes() {
-  local now ps_data
-  now=$(date +%s)
+# Collect raw pane data for deck_format.py.
+# Output format (tab-separated):
+#   target session win_idx win_name pane_idx
+#   path agent status cpu mem owner desc type
+collect_panes() {
+  local ps_data
   ps_data=$(ps -ax -o pid=,ppid=,rss=,%cpu=)
   tmux list-panes -a -F \
-    "#{session_name}:#{window_index}.#{pane_index}${SEP}#{session_name}${SEP}#{window_index}${SEP}#{window_name}${SEP}#{pane_current_command}${SEP}#{pane_index}${SEP}#{pane_title}${SEP}#{pane_current_path}${SEP}#{@pilot-workdir}${SEP}#{window_activity}${SEP}#{pane_pid}${SEP}#{@pilot-host}${SEP}#{@pilot-status}${SEP}#{@pilot-needs-help}" |
+    "#{session_name}:#{window_index}.#{pane_index}${SEP}#{session_name}${SEP}#{window_index}${SEP}#{window_name}${SEP}#{pane_index}${SEP}#{pane_current_path}${SEP}#{@pilot-workdir}${SEP}#{pane_pid}${SEP}#{@pilot-agent}${SEP}#{@pilot-status}${SEP}#{@pilot-needs-help}${SEP}#{@pilot-owner}${SEP}#{@pilot-desc}${SEP}#{@pilot-type}${SEP}#{@pilot-uuid}${SEP}#{window_activity}" |
   while IFS= read -r _line; do
-    # tmux <3.5 escapes 0x1F to literal \037 in format output; decode it
     _line="${_line//\\037/$SEP}"
-    IFS="$SEP" read -r target session win_idx win_name pane_cmd pane_idx title path workdir activity pane_pid pilot_host pilot_status pilot_needs_help <<< "$_line"
+    IFS="$SEP" read -r target session \
+      win_idx win_name pane_idx \
+      path workdir pane_pid \
+      agent status needs_help \
+      owner desc ptype self_uuid activity \
+      <<< "$_line"
     [[ -n "$workdir" ]] && path="$workdir"
-    local elapsed=$((now - activity))
-    local age
-    if [ "$elapsed" -lt 60 ]; then
-      age="active"
-    elif [ "$elapsed" -lt 3600 ]; then
-      age="$((elapsed / 60))m ago"
-    elif [ "$elapsed" -lt 86400 ]; then
-      age="$((elapsed / 3600))h ago"
-    else
-      age="$((elapsed / 86400))d ago"
+    if [[ -n "$needs_help" ]]; then
+      status="waiting"
     fi
-    # Append @host suffix when running on a remote host
-    if [[ -n "$pilot_host" ]]; then
-      session="${session}@${pilot_host}"
-    fi
-    [[ ${#session} -gt $COL_SES ]] && session="${session:0:$((COL_SES - 2))}.."
-    local pane_col="${win_name}:${win_idx}.${pane_idx}"
-    [[ ${#pane_col} -gt $COL_PANE ]] && pane_col="${pane_col:0:$((COL_PANE - 2))}.."
-    local status
-    if [[ -n "$pilot_needs_help" ]]; then
-      status=$(status_icon "waiting")
-    elif [[ -n "$pilot_status" ]]; then
-      status=$(status_icon "$pilot_status")
-    else
-      status=" "
+    # Resolve owner to UUID (cross-machine ID)
+    local owner_uuid=""
+    if [[ -n "$owner" ]]; then
+      owner_uuid=$(command tmux display-message \
+        -t "$owner" -p '#{@pilot-uuid}' \
+        2>/dev/null) || owner_uuid=""
     fi
     local mem cpu
-    mem=$(pane_tree_mem "$pane_pid" <<< "$ps_data")
-    cpu=$(pane_tree_cpu "$pane_pid" <<< "$ps_data")
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-      "$activity" "$target" "$path" \
-      "$session" "$pane_col" "$status" "$age" "$cpu" "$mem"
+    mem=$(pane_tree_mem "$pane_pid" \
+      <<< "$ps_data")
+    cpu=$(pane_tree_cpu "$pane_pid" \
+      <<< "$ps_data")
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$target" "$session" "$win_idx" \
+      "$win_name" "$pane_idx" "$path" \
+      "$agent" "$status" "$cpu" "$mem" \
+      "$owner_uuid" "$desc" "$ptype" "" \
+      "$self_uuid" "$activity"
   done
+}
+
+# Collect panes from a remote tmux via SSH.
+# Uses ||| as delimiter (unit separator doesn't
+# survive SSH quoting). Converts to tabs for
+# parsing. Outputs same format as collect_panes
+# with empty CPU/MEM.
+collect_remote_panes() {
+  local host="$1"
+  local D="@@@"
+  local output
+  output=$(ssh \
+    -o ConnectTimeout=2 \
+    -o BatchMode=yes \
+    "$host" \
+    "tmux list-panes -a -F '#{session_name}${D}#{window_index}${D}#{window_name}${D}#{pane_index}${D}#{pane_current_path}${D}#{@pilot-agent}${D}#{@pilot-status}${D}#{@pilot-desc}${D}#{@pilot-type}${D}#{@pilot-owner-uuid}${D}#{@pilot-uuid}'" \
+    2>/dev/null) || return 0
+  # Reformat with awk (preserves empty fields).
+  # awk preserves empty fields (unlike bash read).
+  echo "$output" | awk -F'@@@' -v h="$host" \
+    'NF>0 {
+      ses=$1; wi=$2; wn=$3; pi=$4; pa=$5
+      ag=$6; st=$7; de=$8; pt=$9; ou=$10; su=$11
+      tgt=ses":"wi"."pi
+      printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\t\t%s\t%s\t%s\t%s\t%s\t\n", \
+        tgt, ses, wi, wn, pi, pa, \
+        ag, st, ou, de, pt, h, su
+    }'
 }
 
 PILOT_DATA=$(mktemp)
 trap 'rm -f "$PILOT_DATA"' EXIT
 
-# Build indexed data file and display list.
-# Usage: build_data [data_file]
-# Writes target<TAB>path to data_file (defaults to $PILOT_DATA).
+# Build indexed data + display via Python
+# formatter. Handles sorting, grouping, dimming,
+# column alignment, and emoji width.
 build_data() {
   local data_file="${1:-$PILOT_DATA}"
-  local tmpfile sorted
-  tmpfile=$(mktemp)
-  sorted=$(mktemp)
-
-  list_panes > "$tmpfile"
-  sort -t$'\t' -k1,1 -rn "$tmpfile" > "$sorted"
-  rm -f "$tmpfile"
-
-  # Data file: target<TAB>path (one per line, indexed)
-  cut -d$'\t' -f2,3 "$sorted" > "$data_file"
-
-  # Display: index<TAB>visible columns
-  local idx=1
-  cut -d$'\t' -f4- "$sorted" | format_display |
-  while IFS= read -r display_line; do
-    printf '%s\t%s\n' "$idx" "$display_line"
-    idx=$((idx + 1))
-  done
-
-  rm -f "$sorted"
+  {
+    collect_panes
+    # Remote panes (sequential)
+    local hosts
+    hosts=$(cached_hosts 2>/dev/null) || hosts=""
+    for h in $hosts; do
+      collect_remote_panes "$h" || true
+    done
+  } | python3 \
+    "$CURRENT_DIR/deck_format.py" \
+    --data-file "$data_file" \
+    --col-pane 26 --col-type 14
 }
 
 # --list mode for reload: rebuild data + display
@@ -220,6 +164,8 @@ fi
 CURRENT_TARGET=$(tmux show-environment -g PILOT_DECK_ORIGIN 2>/dev/null | sed 's/^[^=]*=//')
 
 # Lookup target and path from data file by index
+# Data file format: target<TAB>path<TAB>host
+# Host is empty for local panes.
 lookup() {
   local idx="$1" field="$2"
   if [[ ! "$idx" =~ ^[0-9]+$ ]]; then
@@ -227,9 +173,12 @@ lookup() {
   fi
   local line
   line=$(sed -n "${idx}p" "$PILOT_DATA")
+  local target path host
+  IFS=$'\t' read -r target path host <<< "$line"
   case "$field" in
-    target) printf '%s' "${line%%	*}" ;;
-    path)   printf '%s' "${line#*	}" ;;
+    target) printf '%s' "$target" ;;
+    path)   printf '%s' "$path" ;;
+    host)   printf '%s' "$host" ;;
   esac
 }
 
@@ -263,20 +212,23 @@ while true; do
 
   result=$(fzf --ansi --no-sort --layout=reverse \
       --delimiter '\t' --with-nth 2 \
-      --header "Enter=attach  Ctrl-e/y=scroll  Ctrl-d/u=page  Ctrl-w=wrap
+      --header "Enter=attach  Ctrl-r=refresh
 Alt-d=diff  Alt-s=commit  Alt-x=kill  Alt-l=log
-Alt-p=pause  Alt-r=resume  Alt-n=new  Alt-e=desc  Alt-y=approve
+Alt-p=pause  Alt-r=resume  Alt-n=new
+Alt-e=desc  Alt-y=approve  Alt-t=type  Alt-u=uuid
 $COL_SEP" \
       --header-lines=1 \
       --preview "$CURRENT_DIR/_preview.sh {1} $PILOT_DATA" \
       --preview-window=right:60%:follow:~10 \
-      --bind "ctrl-e:preview-down,ctrl-y:preview-up" \
-      --bind "ctrl-d:preview-half-page-down,ctrl-u:preview-half-page-up" \
+      --bind "ctrl-e:preview-down" \
+      --bind "ctrl-y:preview-up" \
+      --bind "ctrl-d:preview-half-page-down" \
+      --bind "ctrl-u:preview-half-page-up" \
       --bind "ctrl-w:change-preview-window(wrap|nowrap)" \
-      --expect "enter,alt-d,alt-s,alt-x,alt-p,alt-r,alt-n,alt-e,alt-y,alt-l" \
+      --bind "ctrl-r:refresh-preview" \
+      --expect "enter,alt-d,alt-s,alt-x,alt-p,alt-r,alt-n,alt-e,alt-y,alt-l,alt-t,alt-u" \
       "${fzf_start_bind[@]}" \
-    <<< "0	$COL_HEADER
-$display") || break  # esc / ctrl-c → exit
+    <<< "$display") || break  # esc / ctrl-c → exit
 
   # Parse: first line = key pressed, second line = selected
   key=$(head -1 <<< "$result")
@@ -286,7 +238,21 @@ $display") || break  # esc / ctrl-c → exit
   case "$key" in
     enter)
       target=$(lookup "$idx" target) || break
-      tmux switch-client -t "$target"
+      host=$(lookup "$idx" host) || true
+      if [[ -n "$host" ]]; then
+        # Remote: open SSH attach in new window
+        session="${target%%:*}"
+        win_name="${session}@${host}"
+        # Option C: exec into SSH attach.
+        # Replaces the deck process — the popup
+        # becomes the remote session. Detaching
+        # (Ctrl+B d or 'd' in remote) closes the
+        # popup and returns to where you were.
+        exec ssh "$host" -t \
+          "tmux attach -t $session"
+      else
+        tmux switch-client -t "$target"
+      fi
       break
       ;;
     alt-d)
@@ -338,6 +304,35 @@ $display") || break  # esc / ctrl-c → exit
       else
         echo "No watchdog log found"
         sleep 1
+      fi
+      ;;
+    alt-t)
+      target=$(lookup "$idx" target) || continue
+      printf '\n  Type: [s]hell  [a]gent  [d]aemon: '
+      read -rn1 choice
+      case "$choice" in
+        s) tmux set-option -p -t "$target" \
+             @pilot-type shell ;;
+        a) tmux set-option -p -t "$target" \
+             @pilot-type agent ;;
+        d) tmux set-option -p -t "$target" \
+             @pilot-type daemon ;;
+      esac
+      display=$(build_data)
+      ;;
+    alt-u)
+      target=$(lookup "$idx" target) || continue
+      uuid=$(tmux display-message -t "$target" \
+        -p '#{@pilot-uuid}' 2>/dev/null) || uuid=""
+      if [[ -n "$uuid" ]]; then
+        printf '%s' "$uuid" | pbcopy 2>/dev/null \
+          || printf '%s' "$uuid" \
+            | xclip -sel clip 2>/dev/null \
+          || printf '%s' "$uuid" \
+            | xsel --clipboard 2>/dev/null \
+          || true
+        printf '\n  Copied: %s\n' "$uuid"
+        sleep 0.5
       fi
       ;;
     *)

--- a/scripts/deck_format.py
+++ b/scripts/deck_format.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""Deck v2 display formatter.
+
+Reads raw pane data (tab-separated) from stdin,
+outputs formatted display lines for fzf. Handles:
+- Alphabetical sorting by session
+- Owner-based section grouping
+- Dimmed repeated session/agent names
+- Emoji width compensation
+- Remote host separators
+- Orchestrator flags (★, ★⇄)
+
+Input format (one line per pane, tab-separated):
+  target session win_idx win_name pane_idx
+  path agent status cpu mem owner desc type
+
+Output format (tab-separated):
+  index<TAB>formatted_display_line
+
+Also writes a data file (target<TAB>path per line)
+for fzf action lookup.
+"""
+import sys
+import unicodedata
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Pane:
+    target: str = ""
+    session: str = ""
+    win_idx: int = 0
+    win_name: str = ""
+    pane_idx: int = 0
+    path: str = ""
+    agent: str = ""
+    status: str = ""
+    cpu: str = ""
+    mem: str = ""
+    owner: str = ""
+    desc: str = ""
+    pane_type: str = ""
+    host: str = ""  # remote host, empty=local
+    uuid: str = ""   # unique pane identifier
+    activity: int = 0  # window_activity timestamp
+
+
+def display_width(s: str) -> int:
+    """Compute display width accounting for wide
+    chars (CJK, emoji)."""
+    w = 0
+    for ch in s:
+        cat = unicodedata.east_asian_width(ch)
+        if cat in ("W", "F"):
+            w += 2
+        else:
+            w += 1
+    return w
+
+
+def pad_to(s: str, width: int) -> str:
+    """Left-align string to exact display width."""
+    dw = display_width(s)
+    if dw >= width:
+        return s
+    return s + " " * (width - dw)
+
+
+# ANSI escape codes
+DIM = "\033[2m"
+RST = "\033[0m"
+BOLD = "\033[1m"
+
+
+# Column widths
+COL_PANE = 26
+COL_TYPE = 14
+COL_STAT = 2
+COL_CPU = 4
+COL_MEM = 5
+
+
+def set_col_widths(
+    pane: int = 26,
+    typ: int = 14,
+):
+    """Override column widths (for testing)."""
+    global COL_PANE, COL_TYPE
+    COL_PANE = pane
+    COL_TYPE = typ
+
+
+def type_label(
+    agent: str,
+    pane_type: str,
+    flag: str = "",
+) -> str:
+    """Build TYPE column content.
+
+    Flag (★, ★⇄) is inserted between the icon
+    and the agent name: 🤖 ★⇄ claude
+    """
+    if agent:
+        if pane_type == "daemon":
+            return f"⚙ {flag}{agent}"
+        return f"🤖 {flag}{agent}"
+    if pane_type == "daemon":
+        return " ⚙"
+    if pane_type == "agent":
+        return " 🤖"
+    return " $"
+
+
+def stat_icon(
+    status: str,
+    activity: int = 0,
+    now: int = 0,
+) -> str:
+    """Map status to Option C icon.
+
+    If @pilot-status is set (by watchdog or other
+    tooling), uses the semantic status. Otherwise
+    falls back to output-age heuristic from
+    window_activity timestamp.
+    """
+    if status:
+        icons = {
+            "working": "▶",
+            "watching": "▶",
+            "waiting": "!",
+            "paused": "‖",
+            "done": "✓",
+            "stuck": "!",
+        }
+        return icons.get(status, "·")
+    # Fallback: derive from output age
+    if activity and now:
+        elapsed = now - activity
+        if elapsed < 60:
+            return "▶"  # recent output
+        if elapsed < 600:
+            return "·"  # quiet
+    return "·"
+
+
+def pane_name(p: Pane, session_wins: dict,
+              session_panes: dict) -> str:
+    """Build display name for a pane."""
+    name = p.session
+    if p.host:
+        name = f"{p.session}@{p.host}"
+    wc = session_wins.get(p.session, 1)
+    if wc > 1:
+        name = f"{name}/{p.win_name}"
+    pc = session_panes.get(
+        f"{p.session}:{p.win_idx}", 1
+    )
+    if pc > 1 and p.pane_idx > 0:
+        name = f"{name}.{p.pane_idx}"
+    if len(name) > COL_PANE:
+        name = name[: COL_PANE - 2] + ".."
+    return name
+
+
+def format_line(
+    pane_col: str,
+    type_col: str,
+    stat: str,
+    cpu: str,
+    mem: str,
+) -> str:
+    """Format a single pane line with fixed widths."""
+    return (
+        f"{pad_to(pane_col, COL_PANE)}  "
+        f"{pad_to(type_col, COL_TYPE)}  "
+        f"{stat:>{COL_STAT}}  "
+        f"{cpu:>{COL_CPU}}  "
+        f"{mem:>{COL_MEM}}"
+    )
+
+
+def header() -> str:
+    """Column header line."""
+    return (
+        f"{BOLD}"
+        f"{pad_to('PANE', COL_PANE)}  "
+        f"{pad_to('TYPE', COL_TYPE)}  "
+        f"{'ST':>{COL_STAT}}  "
+        f"{'CPU':>{COL_CPU}}  "
+        f"{'MEM':>{COL_MEM}}"
+        f"{RST}"
+    )
+
+
+def separator(label: str) -> str:
+    """Section separator line."""
+    total = (
+        COL_PANE + COL_TYPE + COL_STAT
+        + COL_CPU + COL_MEM + 8
+    )
+    dashes = total - len(label) - 4
+    if dashes < 2:
+        dashes = 2
+    return f"{DIM}── {label} {'─' * dashes}{RST}"
+
+
+def parse_pane(line: str) -> Pane:
+    """Parse a tab-separated pane line.
+
+    13 fields = local pane, 14 fields = remote
+    (14th field is the remote hostname).
+    """
+    parts = line.rstrip("\n").split("\t")
+    while len(parts) < 16:
+        parts.append("")
+    act = 0
+    try:
+        act = int(parts[15]) if parts[15] else 0
+    except ValueError:
+        pass
+    return Pane(
+        target=parts[0],
+        session=parts[1],
+        win_idx=int(parts[2] or "0"),
+        win_name=parts[3],
+        pane_idx=int(parts[4] or "0"),
+        path=parts[5],
+        agent=parts[6],
+        status=parts[7],
+        cpu=parts[8],
+        mem=parts[9],
+        owner=parts[10],
+        desc=parts[11],
+        pane_type=parts[12],
+        host=parts[13],
+        uuid=parts[14],
+        activity=act,
+    )
+
+
+def compute_counts(panes: list[Pane]) -> tuple:
+    """Compute session window/pane counts."""
+    session_wins: dict[str, set] = {}
+    session_panes: dict[str, int] = {}
+    for p in panes:
+        key = p.session
+        if key not in session_wins:
+            session_wins[key] = set()
+        session_wins[key].add(p.win_idx)
+        pkey = f"{p.session}:{p.win_idx}"
+        session_panes[pkey] = (
+            session_panes.get(pkey, 0) + 1
+        )
+    win_counts = {
+        k: len(v) for k, v in session_wins.items()
+    }
+    return win_counts, session_panes
+
+
+def find_orchestrators(panes: list[Pane]) -> set:
+    """Find sessions that own other panes."""
+    owners = set()
+    for p in panes:
+        if p.owner:
+            owners.add(p.owner)
+    return owners
+
+
+def find_peers(
+    panes: list[Pane],
+    orchestrators: set,
+) -> dict[str, str]:
+    """Find peer relationships.
+
+    Returns dict mapping session -> peer session
+    for mutual ownership.
+    """
+    # Map session -> owner session
+    owns: dict[str, set] = {}
+    for p in panes:
+        if p.owner and p.owner in orchestrators:
+            # Find owner's session
+            for o in panes:
+                if o.session == p.owner:
+                    if o.session not in owns:
+                        owns[o.session] = set()
+                    owns[o.session].add(p.session)
+                    break
+    # Find mutual: A owns B and B owns A
+    peers: dict[str, str] = {}
+    for a, a_children in owns.items():
+        for b in a_children:
+            if b in owns and a in owns[b]:
+                peers[a] = b
+                peers[b] = a
+    return peers
+
+
+def format_panes(
+    panes: list[Pane],
+    data_file: str | None = None,
+    now: int = 0,
+) -> list[str]:
+    """Format all panes into display lines.
+
+    Returns list of "idx\\tformatted_line" strings.
+    Writes target\\tpath lines to data_file.
+    """
+    # Split local and remote panes
+    local_panes = [p for p in panes if not p.host]
+    remote_panes = [p for p in panes if p.host]
+
+    win_counts, pane_counts = compute_counts(
+        local_panes
+    )
+
+    # Build OID → session map for owner resolution
+    uuid_to_session: dict[str, str] = {}
+    for p in local_panes:
+        if p.uuid:
+            uuid_to_session[p.uuid] = p.session
+
+    # Determine which sessions are orchestrators
+    # (have agents owned by them via OID)
+    owner_sessions: dict[str, list[Pane]] = {}
+    for p in local_panes + remote_panes:
+        if p.owner:
+            # Resolve owner OID to session name
+            owner_ses = uuid_to_session.get(
+                p.owner, p.owner
+            )
+            if owner_ses not in owner_sessions:
+                owner_sessions[owner_ses] = []
+            owner_sessions[owner_ses].append(p)
+
+    # Find peer relationships
+    peer_map: dict[str, str] = {}
+    for p in local_panes:
+        if p.owner:
+            owner_ses = uuid_to_session.get(
+                p.owner, p.owner
+            )
+            for q in local_panes:
+                if q.session == owner_ses and q.owner:
+                    q_owner_ses = uuid_to_session.get(
+                        q.owner, q.owner
+                    )
+                    if q_owner_ses == p.session:
+                        peer_map[p.session] = owner_ses
+                        peer_map[owner_ses] = p.session
+
+    # Classify panes into groups:
+    # - unowned: no owner, session is not an
+    #   orchestrator
+    # - orchestrator section: orchestrator panes
+    #   (all panes in that session) + its owned
+    #   agents from other sessions
+    unowned: list[Pane] = []
+    sections: dict[str, list[Pane]] = {}
+
+    # First pass: identify orchestrator sessions
+    orch_sessions = set(owner_sessions.keys())
+
+    def resolve_owner(p: Pane) -> str:
+        """Resolve owner OID to session name."""
+        if not p.owner:
+            return ""
+        return uuid_to_session.get(
+            p.owner, p.owner
+        )
+
+    for p in local_panes:
+        if p.session in orch_sessions:
+            if p.session not in sections:
+                sections[p.session] = []
+            sections[p.session].append(p)
+        else:
+            owner_ses = resolve_owner(p)
+            if owner_ses in orch_sessions:
+                if owner_ses not in sections:
+                    sections[owner_ses] = []
+                sections[owner_ses].append(p)
+            else:
+                unowned.append(p)
+
+    # Remote panes: owned → owner section,
+    # unowned → host section
+    unowned_remote: list[Pane] = []
+    for p in remote_panes:
+        owner_ses = resolve_owner(p)
+        if owner_ses in orch_sessions:
+            if owner_ses not in sections:
+                sections[owner_ses] = []
+            sections[owner_ses].append(p)
+        else:
+            unowned_remote.append(p)
+
+    # Sort within each group
+    def sort_key(p: Pane) -> tuple:
+        return (p.session, p.win_idx, p.pane_idx)
+
+    unowned.sort(key=sort_key)
+    for k in sections:
+        sections[k].sort(key=sort_key)
+
+    # Build output
+    lines: list[str] = []
+    data_lines: list[str] = []
+    idx = 1
+    prev_ses = ""
+    prev_ag = ""
+
+    def emit_pane(p: Pane, flag: str = ""):
+        nonlocal idx, prev_ses, prev_ag
+        name = pane_name(
+            p, win_counts, pane_counts
+        )
+        tc = type_label(
+            p.agent, p.pane_type, flag
+        )
+        st = stat_icon(
+            p.status, p.activity, now
+        ) if (
+            p.agent or p.pane_type
+            or p.status or p.activity
+        ) else " "
+        cpu = p.cpu or ""
+        mem = p.mem or ""
+
+        raw = format_line(name, tc, st, cpu, mem)
+
+        # Dim repeated session name
+        if (p.session == prev_ses
+                and prev_ses
+                and not p.host):
+            slen = len(p.session)
+            raw = (
+                f"{DIM}{raw[:slen]}{RST}"
+                f"{raw[slen:]}"
+            )
+        # Dim repeated agent
+        if (p.agent == prev_ag
+                and prev_ag
+                and p.agent):
+            # Find agent in the line and dim it
+            pos = raw.find(p.agent)
+            if pos >= 0:
+                end = pos + len(p.agent)
+                raw = (
+                    f"{raw[:pos]}"
+                    f"{DIM}{p.agent}{RST}"
+                    f"{raw[end:]}"
+                )
+        prev_ses = p.session
+        prev_ag = p.agent
+
+        lines.append(f"{idx}\t{raw}")
+        data_lines.append(
+            f"{p.target}\t{p.path}\t{p.host}"
+        )
+        idx += 1
+
+    def emit_separator(label: str):
+        nonlocal idx, prev_ses, prev_ag
+        # Empty line
+        lines.append(f"{idx}\t")
+        data_lines.append("\t")
+        idx += 1
+        # Separator
+        lines.append(f"{idx}\t{separator(label)}")
+        data_lines.append("\t")
+        idx += 1
+        prev_ses = ""
+        prev_ag = ""
+
+    # Emit unowned panes
+    for p in unowned:
+        emit_pane(p)
+
+    # Emit orchestrator sections (sorted by name)
+    for orch_ses in sorted(sections.keys()):
+        section_panes = sections[orch_ses]
+        # Count non-orchestrator agents
+        agent_count = sum(
+            1 for p in section_panes
+            if p.session != orch_ses
+        )
+        emit_separator(
+            f"{orch_ses} ({agent_count} agents)"
+        )
+        for p in section_panes:
+            flag = ""
+            if (p.session == orch_ses
+                    and p.pane_idx == 0
+                    and p.win_idx == 0):
+                # Main pane of the orchestrator
+                if p.session in peer_map:
+                    flag = "★⇄ "
+                else:
+                    flag = "★  "
+            elif (p.session != orch_ses
+                    and p.session in orch_sessions):
+                # A different orchestrator owned
+                # by this one (peer or child)
+                if p.session in peer_map:
+                    flag = "★⇄ "
+                else:
+                    flag = "★  "
+            emit_pane(p, flag)
+
+    # Unowned remote panes grouped by host
+    if unowned_remote:
+        # Group by host
+        hosts: dict[str, list[Pane]] = {}
+        for p in unowned_remote:
+            if p.host not in hosts:
+                hosts[p.host] = []
+            hosts[p.host].append(p)
+
+        for host_name in sorted(hosts.keys()):
+            host_panes = sorted(
+                hosts[host_name], key=sort_key
+            )
+            emit_separator(host_name)
+            for p in host_panes:
+                emit_pane(p)
+
+    # Write data file
+    if data_file:
+        with open(data_file, "w") as f:
+            for dl in data_lines:
+                f.write(dl + "\n")
+
+    return lines
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--data-file", required=True,
+        help="Path to write target/path data",
+    )
+    parser.add_argument(
+        "--col-pane", type=int, default=26,
+    )
+    parser.add_argument(
+        "--col-type", type=int, default=14,
+    )
+    args = parser.parse_args()
+    set_col_widths(args.col_pane, args.col_type)
+
+    import time
+    now = int(time.time())
+
+    panes = []
+    for line in sys.stdin:
+        if line.strip():
+            panes.append(parse_pane(line))
+
+    # Print header
+    print(f"0\t{header()}")
+
+    # Print formatted panes
+    for out_line in format_panes(
+        panes, args.data_file, now=now
+    ):
+        print(out_line)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/new-agent.sh
+++ b/scripts/new-agent.sh
@@ -8,12 +8,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$CURRENT_DIR/_agents.sh"
 source "$CURRENT_DIR/_hosts.sh"
 
-# Detect available coding agents from the shared list
-agents=""
-for name in $KNOWN_AGENTS; do
-  command -v "$name" &>/dev/null && agents+="${name}"$'\n'
-done
-agents="${agents%$'\n'}"
+agents=$(list_available_agents)
 
 if [[ -z "$agents" ]]; then
   printf '\n  No AI agents found.\n'
@@ -124,7 +119,8 @@ fi
 if $multi_agent; then
   printf '\n  [%d/%d] Select an agent %s\n' \
     "$step" "$total" "$esc_hint"
-  agent=$(fzf --no-info --no-separator --height=4 --reverse <<< "$agents")
+  agent=$(fzf --no-info --no-separator \
+    --height=~100% --reverse <<< "$agents")
   ((step++))
 else
   agent="$agents"

--- a/scripts/spawn.sh
+++ b/scripts/spawn.sh
@@ -152,6 +152,20 @@ if [[ "$mode" == "remote-tmux" ]]; then
   owner_cmd=""
   if [[ -n "$owner" ]]; then
     owner_cmd=" && tmux set-option -p -t '$session_name' @pilot-owner '$owner'"
+    # Get or create a UUID for the owner pane.
+    # This is the cross-machine identifier.
+    local owner_uuid
+    owner_uuid=$(tmux display-message \
+      -t "$owner" \
+      -p '#{@pilot-uuid}' 2>/dev/null) \
+      || owner_uuid=""
+    if [[ -z "$owner_uuid" ]]; then
+      owner_uuid=$(uuidgen | tr '[:upper:]' \
+        '[:lower:]' | cut -c1-12)
+      tmux set-option -p -t "$owner" \
+        @pilot-uuid "$owner_uuid" 2>/dev/null
+    fi
+    owner_cmd+=" && tmux set-option -p -t '$session_name' @pilot-owner-uuid '$owner_uuid'"
   fi
   tier_cmd=""
   if [[ -n "$tier" ]]; then

--- a/tests/test_deck_format.py
+++ b/tests/test_deck_format.py
@@ -1,0 +1,421 @@
+"""Tests for deck_format.py display formatter."""
+import os
+import sys
+import tempfile
+import pytest
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__),
+        "..", "scripts",
+    ),
+)
+from deck_format import (
+    Pane,
+    format_panes,
+    format_line,
+    type_label,
+    stat_icon,
+    pane_name,
+    header,
+    separator,
+    display_width,
+    pad_to,
+    set_col_widths,
+    DIM,
+    RST,
+    COL_PANE,
+    COL_TYPE,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_widths():
+    set_col_widths(26, 14)
+    yield
+
+
+# --- Unit tests ---
+
+class TestDisplayWidth:
+    def test_ascii(self):
+        assert display_width("hello") == 5
+
+    def test_emoji(self):
+        # 🤖 is a wide char (2 cells)
+        assert display_width("🤖") == 2
+
+    def test_mixed(self):
+        assert display_width("🤖 claude") == 9
+
+
+class TestPadTo:
+    def test_short_string(self):
+        result = pad_to("hi", 10)
+        assert len(result) == 10
+        assert result == "hi        "
+
+    def test_emoji_padding(self):
+        # 🤖 is 2 cells, so padding to 10
+        # needs 8 more spaces
+        result = pad_to("🤖", 10)
+        assert display_width(result) == 10
+
+
+class TestTypeLabel:
+    def test_agent(self):
+        result = type_label("claude", "")
+        assert "🤖" in result
+        assert "claude" in result
+
+    def test_daemon(self):
+        result = type_label("watchdog", "daemon")
+        assert "⚙" in result
+        assert "watchdog" in result
+
+    def test_shell(self):
+        result = type_label("", "")
+        assert "$" in result
+        assert "🤖" not in result
+
+    def test_shell_daemon(self):
+        result = type_label("", "daemon")
+        assert "⚙" in result
+
+
+class TestStatIcon:
+    def test_working(self):
+        assert stat_icon("working") == "▶"
+
+    def test_waiting(self):
+        assert stat_icon("waiting") == "!"
+
+    def test_done(self):
+        assert stat_icon("done") == "✓"
+
+    def test_paused(self):
+        assert stat_icon("paused") == "‖"
+
+    def test_unknown(self):
+        assert stat_icon("") == "·"
+
+    def test_idle(self):
+        assert stat_icon("idle") == "·"
+
+
+class TestPaneName:
+    def _pane(self, **kw):
+        return Pane(**kw)
+
+    def test_single_window_single_pane(self):
+        p = self._pane(
+            session="backup", win_name="main",
+            win_idx=0, pane_idx=0,
+        )
+        wins = {"backup": 1}
+        panes = {"backup:0": 1}
+        assert pane_name(p, wins, panes) == "backup"
+
+    def test_multi_window(self):
+        p = self._pane(
+            session="nexus", win_name="watchdog",
+            win_idx=1, pane_idx=0,
+        )
+        wins = {"nexus": 2}
+        panes = {"nexus:0": 1, "nexus:1": 1}
+        assert (
+            pane_name(p, wins, panes)
+            == "nexus/watchdog"
+        )
+
+    def test_multi_pane(self):
+        p = self._pane(
+            session="frugal", win_name="main",
+            win_idx=0, pane_idx=1,
+        )
+        wins = {"frugal": 1}
+        panes = {"frugal:0": 3}
+        assert (
+            pane_name(p, wins, panes)
+            == "frugal.1"
+        )
+
+    def test_multi_window_multi_pane(self):
+        p = self._pane(
+            session="nexus", win_name="watchdog",
+            win_idx=1, pane_idx=1,
+        )
+        wins = {"nexus": 2}
+        panes = {"nexus:1": 2}
+        assert (
+            pane_name(p, wins, panes)
+            == "nexus/watchdog.1"
+        )
+
+    def test_remote_host(self):
+        p = self._pane(
+            session="issue-42",
+            win_name="main",
+            win_idx=0, pane_idx=0,
+            host="desktop",
+        )
+        wins = {"issue-42": 1}
+        panes = {"issue-42:0": 1}
+        assert (
+            pane_name(p, wins, panes)
+            == "issue-42@desktop"
+        )
+
+    def test_truncation(self):
+        p = self._pane(
+            session="very-long-session-name-here",
+            win_name="main",
+            win_idx=0, pane_idx=0,
+        )
+        wins = {"very-long-session-name-here": 1}
+        panes = {
+            "very-long-session-name-here:0": 1
+        }
+        result = pane_name(p, wins, panes)
+        assert len(result) <= 26
+        assert result.endswith("..")
+
+
+# --- Integration tests ---
+
+def _make_panes():
+    """Create a realistic set of panes."""
+    return [
+        Pane(
+            target="backup:0.0",
+            session="backup",
+            win_idx=0, win_name="main",
+            pane_idx=0, path="/home",
+            agent="claude", status="working",
+            cpu="0%", mem="423M",
+            uuid="aaa11111",
+        ),
+        Pane(
+            target="frugal:0.0",
+            session="frugal",
+            win_idx=0, win_name="orch",
+            pane_idx=0, path="/home",
+            agent="claude", status="",
+            cpu="0%", mem="977M",
+            owner="bbb22222",  # owned by swarm
+            uuid="ccc33333",
+        ),
+        Pane(
+            target="frugal:0.1",
+            session="frugal",
+            win_idx=0, win_name="orch",
+            pane_idx=1, path="/home",
+            agent="", status="",
+            cpu="0%", mem="560M",
+            uuid="ddd44444",
+        ),
+        Pane(
+            target="issue-904:0.0",
+            session="issue-904",
+            win_idx=0, win_name="main",
+            pane_idx=0, path="/work",
+            agent="vibe", status="working",
+            cpu="23%", mem="236M",
+            owner="ccc33333",  # owned by frugal
+            uuid="eee55555",
+        ),
+        Pane(
+            target="nexus:0.0",
+            session="nexus",
+            win_idx=0, win_name="dash",
+            pane_idx=0, path="/home",
+            agent="", status="",
+            cpu="0%", mem="130M",
+            uuid="fff66666",
+        ),
+        Pane(
+            target="nexus:1.0",
+            session="nexus",
+            win_idx=1, win_name="watchdog",
+            pane_idx=0, path="/home",
+            agent="", status="working",
+            cpu="0%", mem="62M",
+            pane_type="daemon",
+            uuid="ggg77777",
+        ),
+        Pane(
+            target="swarm:0.0",
+            session="swarm",
+            win_idx=0, win_name="main",
+            pane_idx=0, path="/home",
+            agent="claude", status="working",
+            cpu="9%", mem="1.3G",
+            owner="ccc33333",  # owned by frugal
+            uuid="bbb22222",
+        ),
+    ]
+
+
+class TestFormatPanes:
+    def test_all_panes_present(self):
+        """Every pane appears exactly once."""
+        panes = _make_panes()
+        lines = format_panes(panes)
+        # Filter out separator/empty lines
+        content = [
+            l for l in lines
+            if "\t" in l
+            and l.split("\t", 1)[1].strip()
+            and not l.split("\t", 1)[1]
+            .startswith(DIM + "──")
+        ]
+        assert len(content) == len(panes)
+
+    def test_alphabetical_unowned(self):
+        """Unowned panes are sorted alphabetically."""
+        panes = _make_panes()
+        lines = format_panes(panes)
+        content = [
+            l.split("\t", 1)[1]
+            for l in lines
+            if "\t" in l
+            and l.split("\t", 1)[1].strip()
+            and not l.split("\t", 1)[1]
+            .startswith(DIM + "──")
+        ]
+        # First panes should be unowned:
+        # backup, frugal.1, nexus/dash,
+        # nexus/watchdog
+        assert "backup" in content[0]
+
+    def test_orchestrator_sections(self):
+        """Orchestrator sections have headers."""
+        panes = _make_panes()
+        lines = format_panes(panes)
+        text = "\n".join(
+            l.split("\t", 1)[1]
+            for l in lines if "\t" in l
+        )
+        assert "frugal" in text
+        assert "swarm" in text
+
+    def test_orchestrator_in_own_section(self):
+        """Orchestrator pane appears in its own
+        section, not under its peer's section."""
+        panes = _make_panes()
+        lines = format_panes(panes)
+        # Find frugal section
+        in_frugal = False
+        frugal_panes = []
+        for l in lines:
+            if "\t" not in l:
+                continue
+            content = l.split("\t", 1)[1]
+            if "── frugal" in content:
+                in_frugal = True
+                continue
+            if in_frugal and content.startswith(
+                DIM + "──"
+            ):
+                break
+            if in_frugal and content.strip():
+                frugal_panes.append(content)
+        # frugal's own pane should be here
+        assert any(
+            "frugal" in p and "★" in p
+            for p in frugal_panes
+        ), (
+            f"frugal orchestrator pane not in "
+            f"frugal section: {frugal_panes}"
+        )
+
+    def test_peer_flag(self):
+        """Peer orchestrators have ★⇄ flag."""
+        panes = _make_panes()
+        lines = format_panes(panes)
+        text = "\n".join(
+            l.split("\t", 1)[1]
+            for l in lines if "\t" in l
+        )
+        # Both frugal and swarm own each other
+        assert "★⇄" in text
+
+    def test_star_flag(self):
+        """Orchestrators have ★ flag."""
+        panes = _make_panes()
+        lines = format_panes(panes)
+        text = "\n".join(
+            l.split("\t", 1)[1]
+            for l in lines if "\t" in l
+        )
+        assert "★" in text
+
+    def test_dimming_repeated_session(self):
+        """Repeated session names are dimmed."""
+        panes = _make_panes()
+        lines = format_panes(panes)
+        text = "\n".join(
+            l.split("\t", 1)[1]
+            for l in lines if "\t" in l
+        )
+        # nexus appears twice (dash + watchdog)
+        # — second should be dimmed
+        assert DIM in text
+
+    def test_data_file(self):
+        """Data file has correct target/path."""
+        panes = _make_panes()
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False
+        ) as f:
+            data_path = f.name
+        try:
+            format_panes(panes, data_path)
+            with open(data_path) as f:
+                data = f.read().strip().split("\n")
+            # Should have entries for all panes
+            # plus separator lines (empty)
+            targets = [
+                l.split("\t")[0]
+                for l in data if l.split("\t")[0]
+            ]
+            assert "backup:0.0" in targets
+            assert "swarm:0.0" in targets
+        finally:
+            os.unlink(data_path)
+
+    def test_no_duplicate_panes(self):
+        """Each target appears exactly once in
+        data file."""
+        panes = _make_panes()
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False
+        ) as f:
+            data_path = f.name
+        try:
+            format_panes(panes, data_path)
+            with open(data_path) as f:
+                data = f.read().strip().split("\n")
+            targets = [
+                l.split("\t")[0]
+                for l in data if l.split("\t")[0]
+            ]
+            assert len(targets) == len(set(targets))
+        finally:
+            os.unlink(data_path)
+
+    def test_shell_type(self):
+        """Non-agent panes show $ type."""
+        panes = [
+            Pane(
+                target="shell:0.0",
+                session="shell",
+                win_idx=0, win_name="main",
+                pane_idx=0, path="/home",
+            ),
+        ]
+        lines = format_panes(panes)
+        text = lines[0].split("\t", 1)[1]
+        assert "$" in text
+        assert "🤖" not in text


### PR DESCRIPTION
## Summary
- Sort alphabetically by session, dim repeated session/agent names (ANSI dim, still searchable in fzf)
- Add TYPE column: `🤖 agent_name`, `⚙ daemon`, `$` shell
- New STAT icons: `▶` working, `!` attention, `·` idle, `✓` done, `‖` paused
- Show all `@pilot-*` fields in MCP `list_agents` output (only non-empty)
- Show all fields in deck preview pane (skip empty)
- Pause sends `Escape` (interrupts without killing), resume sends `resume` (universal instruction)
- `Alt-t` type picker via `tmux display-menu`
- `Ctrl-r` to refresh preview
- `pane_id` appended to `PANE_FORMAT_FIELDS` (backward compatible, at end)
- Add `.gitignore`

## Test plan
- [ ] Open deck (`Ctrl+S W`), verify alphabetical sort
- [ ] Verify dimmed repeated session/agent names
- [ ] Verify TYPE shows agent name for agent panes, `$` for shells
- [ ] Test `Alt-t` type picker
- [ ] Test `Alt-p` pause (sends Escape) and `Alt-r` resume
- [ ] Verify fzf search matches dimmed session names
- [ ] Verify `Ctrl-r` refreshes preview
- [ ] Test `list_agents` MCP shows all fields