### PR TITLE
Add Antigravity CLI (agy) as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI agent manager for tmux. Launch, monitor, and orchestrate multiple coding agents from your terminal.
 
-Supports **Claude Code**, **Gemini CLI**, **Aider**, **Codex**, **Goose**, and **Open Interpreter** — auto-detects which agents are installed.
+Supports **Claude Code**, **Gemini CLI**, **Antigravity CLI** (`agy`), **Aider**, **Codex**, **Goose**, **Vibe**, and **Open Interpreter** — auto-detects which agents are installed.
 
 WARNING: THIS PLUGIN IS VIBE-CODED. USE IT AT YOUR OWN RISK. 
 
@@ -195,7 +195,7 @@ tmux-pilot will display in the deck.
 | Variable | Set by | Read by | Values |
 |----------|--------|---------|--------|
 | `@pilot-uuid` | pilot.tmux (auto) | deck, spawn | Unique pane identifier (12-char hex) |
-| `@pilot-agent` | spawn.sh, auto-detect | deck, monitor | claude, gemini, vibe, ... |
+| `@pilot-agent` | spawn.sh, auto-detect | deck, monitor | claude, gemini, agy, vibe, ... |
 | `@pilot-desc` | spawn.sh, agent | deck | Task description |
 | `@pilot-workdir` | agent hook | deck, kill.sh | Current dir |
 | `@pilot-status` | external tool, deck | deck | Status enum (see below) |

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -194,7 +194,7 @@ def spawn_agent(
     """Create a new AI agent in its own tmux session.
 
     Args:
-        agent: Agent name (claude, gemini, aider, codex, goose, interpreter, vibe).
+        agent: Agent name (claude, gemini, agy, aider, codex, goose, interpreter, vibe).
         prompt: The task prompt to send to the agent.
         directory: Working directory for the agent session.
         session_name: Optional session name (auto-generated from prompt if omitted).
@@ -278,7 +278,7 @@ def spawn_agent(
     # Start pipe-pane for agents that use alternate screen
     # (prompt_toolkit TUI). capture-pane -p returns empty
     # for these agents without pipe-pane logging.
-    if agent in ("vibe", "aider") and effective_mode != "remote-tmux":
+    if agent in ("vibe", "aider", "agy") and effective_mode != "remote-tmux":
         target = f"{name}:0.0"
         log_file = f"/tmp/tmux-pipe-{name}.log"
         _run(["tmux", "pipe-pane", "-t", target, "-o", f"cat >> {log_file}"])

--- a/scripts/_agents.sh
+++ b/scripts/_agents.sh
@@ -4,7 +4,7 @@
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Single source of truth for supported agent names.
-KNOWN_AGENTS="claude gemini aider codex goose interpreter vibe"
+KNOWN_AGENTS="claude gemini agy aider codex goose interpreter vibe"
 
 # Check if an agent binary is available.
 # Searches PATH, npm global bin, nvm, and common
@@ -62,6 +62,7 @@ agent_build_cmd() {
   # shellcheck disable=SC2086
   case "$agent" in
     gemini)      cmd_args=(bash -lc 'exec gemini -y "$0"' "$prompt") ;;
+    agy)         cmd_args=(bash -lc 'exec agy --dangerously-skip-permissions -i "$0"' "$prompt") ;;
     vibe)        cmd_args=(vibe --agent auto-approve "$prompt") ;;
     aider)       cmd_args=(bash -lc "exec aider --yes-always $extra_args") ;;
     goose)       cmd_args=(goose run "$prompt") ;;

--- a/scripts/_preview.sh
+++ b/scripts/_preview.sh
@@ -340,7 +340,7 @@ case "$pane_cmd" in
           && "$_start" == *"$pilot_agent"* ]]; then
         display_cmd="$pilot_agent"
       else
-        for _a in claude gemini aider codex \
+        for _a in claude gemini agy aider codex \
             goose interpreter vibe; do
           if [[ "$_start" == *"$_a"* ]]; then
             display_cmd="$_a"

--- a/scripts/new-agent.sh
+++ b/scripts/new-agent.sh
@@ -12,7 +12,7 @@ agents=$(list_available_agents)
 
 if [[ -z "$agents" ]]; then
   printf '\n  No AI agents found.\n'
-  printf '  Install claude, gemini, aider, or codex.\n\n'
+  printf '  Install claude, gemini, agy, aider, or codex.\n\n'
   printf '  Press Enter to close.'
   read -r
   exit 1

--- a/tests/test_agent_launcher.py
+++ b/tests/test_agent_launcher.py
@@ -1,0 +1,77 @@
+"""Shell-level tests for scripts/_agents.sh.
+
+Verifies KNOWN_AGENTS membership and the
+command array produced by agent_build_cmd.
+"""
+
+import os
+import subprocess
+import unittest
+
+SCRIPT = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "scripts",
+    "_agents.sh",
+)
+
+
+def _build_cmd(agent: str, prompt: str) -> str:
+    """Run agent_build_cmd via bash and return
+    the space-quoted cmd_args."""
+    out = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"source {SCRIPT} && cmd_args=() && "
+            f'agent_build_cmd {agent} "{prompt}" '
+            f'&& printf "%q " "${{cmd_args[@]}}"',
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout
+
+
+class TestKnownAgents(unittest.TestCase):
+
+    def test_known_agents_contains_agy(self):
+        out = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"source {SCRIPT} "
+                f"&& echo $KNOWN_AGENTS",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertIn("agy", out.stdout.split())
+
+
+class TestAgentBuildCmd(unittest.TestCase):
+
+    def test_agy_uses_dangerously_skip(self):
+        cmd = _build_cmd("agy", "do thing")
+        self.assertIn(
+            "--dangerously-skip-permissions", cmd
+        )
+        self.assertIn("-i", cmd)
+        self.assertIn("agy", cmd)
+
+    def test_gemini_uses_yolo(self):
+        cmd = _build_cmd("gemini", "do thing")
+        self.assertIn("-y", cmd)
+
+    def test_claude_uses_dangerously_skip(self):
+        cmd = _build_cmd("claude", "do thing")
+        self.assertIn(
+            "CLAUDE_CODE_DISABLE_AUTOCOMPLETE",
+            cmd,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vibe_fallback.py
+++ b/tests/test_vibe_fallback.py
@@ -91,6 +91,27 @@ class TestVibeFallback(unittest.TestCase):
         self.assertTrue(len(pipe_calls) > 0)
 
     @patch("server._run")
+    def test_spawn_starts_pipe_pane_for_agy(
+        self, mock_run
+    ):
+        """spawn_agent starts pipe-pane for agy."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="agy-session"
+        )
+
+        server.spawn_agent(
+            agent="agy",
+            prompt="test",
+            directory="/tmp",
+        )
+
+        pipe_calls = [
+            c for c in mock_run.call_args_list
+            if "pipe-pane" in c[0][0]
+        ]
+        self.assertTrue(len(pipe_calls) > 0)
+
+    @patch("server._run")
     @patch("server.os.path.exists")
     @patch("server.os.remove")
     def test_kill_cleans_up_log(


### PR DESCRIPTION
Adds `agy` (Antigravity CLI) to KNOWN_AGENTS so the launcher, deck, MCP spawner, and previews recognize it like claude/gemini/vibe.

## Changes

- `scripts/_agents.sh`: KNOWN_AGENTS entry + `agent_build_cmd` case using `agy --dangerously-skip-permissions -i "<prompt>"` (interactive YOLO).
- `scripts/_preview.sh`, `scripts/new-agent.sh`: agy in hint lists.
- `mcp/server.py`: agy added to pipe-pane special case (paste-buffer delivery).
- `README.md`: agent list + pilot-agent values table updated.
- `tests/test_agent_launcher.py` (new): KNOWN_AGENTS + cmd_args coverage.
- `tests/test_vibe_fallback.py`: agy pipe-pane spawn test.

All 91 tests pass.