### PR TITLE
Pin fastmcp <3.2 in MCP server inline deps

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["fastmcp>=2.0"]
+# dependencies = ["fastmcp>=2.0,<3.2"]
 # ///
 """tmux-pilot MCP server — agent lifecycle tools for MCP-capable clients."""
 


### PR DESCRIPTION
## Summary

`mcp/server.py` declares `dependencies = ["fastmcp>=2.0"]` in its
inline script header. fastmcp 3.2 split the distribution into a
'slim' package whose top-level module no longer exposes `FastMCP`,
so `from fastmcp import FastMCP` raises `ImportError` once uv
resolves the unpinned constraint to 3.3.x.

Pin to `<3.2` until the server is migrated to the new import path.

## Test plan

- [x] `uv run --script mcp/server.py` starts without ImportError
- [x] MCP client reconnects to the server over stdio