### PR TITLE
_keys.sh: sleep before Enter on default branch so paste-buffer settles

### DIFF
--- a/scripts/_keys.sh
+++ b/scripts/_keys.sh
@@ -36,8 +36,13 @@ send_text() {
       ;;
   esac
 
-  # Default: send Enter unless suppressed.
+  # Default: sleep before Enter so paste-buffer settles. Without it
+  # Claude Code reads Enter before the paste completes and buffers
+  # it as a newline inside the composer — message stuck, not sent.
+  # Mirrors the agent-aware delays above (alexlibraria #3375 was
+  # the matching fix on the remote path).
   if [[ -z "$no_enter" ]]; then
+    sleep 0.1
     tmux send-keys -t "$target" Enter
   fi
 }


### PR DESCRIPTION
Messages sent from Cortex web to a Claude Code pane were buffering as text in the composer instead of submitting — same race that alexlibraria PR #3376 (remote_send_keys) fixed on the SSH path. The local _keys.sh had agent-aware delays for vibe and gemini but the default branch sent Enter immediately after paste-buffer; on Claude Code that loses to the async paste handler and the Enter becomes a newline inside the composer.